### PR TITLE
feat(all-subcommands): added dump flag and improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 kubearmor*
 accuknoxcli
 out/
+knoxctl_out/*
 .vscode
 .idea
 # Test binary, built with `go test -c`

--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -39,9 +39,9 @@ func init() {
 	rootCmd.AddCommand(discoverCmd)
 	discoverCmd.Flags().StringVar(&parseArgs.GRPC, "gRPC", "", "gRPC server information")
 	discoverCmd.Flags().StringVarP(&parseArgs.Format, "format", "f", "", "Format: json or yaml")
+	discoverCmd.Flags().BoolVar(&parseArgs.Dump, "dump", false, "Dump policies to knoxctl_out directory and skip TUI")
 	discoverCmd.Flags().StringSliceVarP(&parseArgs.Kind, "policy", "p", []string{"KubeArmorPolicy"}, "Type of policies to be discovered: NetworkPolicy|KubeArmorPolicy|KubeArmorHostPolicy")
 	discoverCmd.Flags().StringSliceVarP(&parseArgs.Namespace, "namespace", "n", []string{}, "Filter by Namespace")
 	discoverCmd.Flags().StringSliceVarP(&parseArgs.Labels, "labels", "l", []string{}, "Filter by policy Label")
 	discoverCmd.Flags().StringSliceVarP(&parseArgs.Source, "source", "s", []string{}, "Filter by policy FromSource")
-	discoverCmd.Flags().BoolVar(&parseArgs.IncludeNetwork, "includenet", false, "Include network rules in system policies")
 }

--- a/cmd/recommend.go
+++ b/cmd/recommend.go
@@ -42,4 +42,5 @@ func init() {
 	recommendCmd.Flags().StringVarP(&recommendOptions.Outdir, "outdir", "o", "out", "Output folder to write policies")
 	recommendCmd.Flags().StringSliceVarP(&recommendOptions.Tags, "tag", "t", []string{}, "Tags to apply. Eg. PCI-DSS,MITRE")
 	recommendCmd.Flags().StringVarP(&recommendOptions.Grpc, "gRPC", "", "", "gRPC address of discovery engine")
+	recommendCmd.Flags().BoolVar(&recommendOptions.Dump, "dump", false, "Dump policies to knoxctl_out directory and skip TUI")
 }

--- a/cmd/summary.go
+++ b/cmd/summary.go
@@ -42,6 +42,8 @@ func init() {
 	summaryCmd.Flags().StringArrayVarP(&summaryOptions.Namespace, "namespace", "n", []string{}, "Namespace")
 	summaryCmd.Flags().StringVarP(&summaryOptions.Operation, "operation", "o", "", "Summary filter type : process|file|network ")
 	summaryCmd.Flags().BoolVar(&summaryOptions.RevDNSLookup, "rev-dns-lookup", false, "Reverse DNS Lookup")
-	summaryCmd.Flags().StringVarP(&summaryOptions.Format, "format", "f", "json", "Print data on console in JSON format")
+	summaryCmd.Flags().StringVarP(&summaryOptions.View, "view", "v", "json", "Print data on console in table or json format")
+	summaryCmd.Flags().BoolVar(&summaryOptions.Dump, "dump", false, "Dump json data to knoxctl_out directory and skip TUI")
+	summaryCmd.Flags().BoolVar(&summaryOptions.Glance, "glance", false, "Glance at the summary data")
 	//summaryCmd.Flags().BoolVar(&summaryOptions.Aggregation, "agg", false, "Aggregate destination files/folder path")
 }

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	k8s.io/api v0.28.3
 	k8s.io/apiextensions-apiserver v0.27.3
 	k8s.io/apimachinery v0.28.3
+	k8s.io/klog/v2 v2.100.1
 	sigs.k8s.io/yaml v1.4.0
 )
 
@@ -324,7 +325,6 @@ require (
 	k8s.io/cli-runtime v0.28.3 // indirect
 	k8s.io/client-go v0.28.3 // indirect
 	k8s.io/component-base v0.28.3 // indirect
-	k8s.io/klog/v2 v2.100.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20230717233707-2695361300d9 // indirect
 	k8s.io/kubectl v0.28.3 // indirect
 	k8s.io/pod-security-admission v0.27.1 // indirect

--- a/pkg/discover/discover.go
+++ b/pkg/discover/discover.go
@@ -70,8 +70,9 @@ func Policy(c *k8s.Client, parsedArgs *Options) error {
 	if len(policyForest.Namespaces) == 0 {
 		fmt.Println("No discovered policies were found.")
 		return nil
-	} else {
-		StartTUI(policyForest)
+	} else if parsedArgs.Dump {
+		dump(policyForest)
+		return nil
 	}
 
 	var errorSlice []string

--- a/pkg/discover/dump.go
+++ b/pkg/discover/dump.go
@@ -1,0 +1,84 @@
+package discover
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	policyType "github.com/accuknox/dev2/discover/pkg/common"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/klog/v2"
+)
+
+func dump(forest *PolicyForest) error {
+	dirPath := "knoxctl_out"
+	if err := os.MkdirAll(dirPath, os.ModePerm); err != nil {
+		return fmt.Errorf("failed to create directory: %v", err)
+	}
+
+	klog.Info("Len of forest.Namespaces: ", len(forest.Namespaces))
+	for ns, nsBucket := range forest.Namespaces {
+		nsDirPath := filepath.Join(dirPath, ns)
+		if err := os.MkdirAll(nsDirPath, os.ModePerm); err != nil {
+			return fmt.Errorf("failed to create namespace directory '%s': %v", nsDirPath, err)
+		}
+
+		for _, policies := range nsBucket.KubearmorPolicies.Labels {
+			for _, policy := range policies {
+				filename := fmt.Sprintf("%s-KAP-Label-%s.yaml", ns, policy.Metadata.Name)
+				if err := writePolicyToFile(policy, nsDirPath, filename); err != nil {
+					continue
+				}
+			}
+		}
+
+		// Handle KubeArmorPolicies in Actions
+		for _, policies := range nsBucket.KubearmorPolicies.Actions {
+			for _, policy := range policies {
+				filename := fmt.Sprintf("%s-KAP-Action-%s.yaml", ns, policy.Metadata.Name)
+				if err := writePolicyToFile(policy, nsDirPath, filename); err != nil {
+					continue
+				}
+			}
+		}
+
+		// Handle NetworkPolicies in Types
+		for typeKey, policies := range nsBucket.NetworkPolicies.Types {
+			for _, policy := range policies {
+				filename := fmt.Sprintf("%s-NP-Type-%s-%s.yaml", ns, typeKey, policy.ObjectMeta.Name)
+				if err := writeNetworkPolicyToFile(policy, nsDirPath, filename); err != nil {
+					continue
+				}
+			}
+		}
+		// Handle NetworkPolicies in Protocols
+		for protocolKey, policies := range nsBucket.NetworkPolicies.Protocols {
+			for _, policy := range policies {
+				filename := fmt.Sprintf("%s-NP-Protocol-%s-%s.yaml", ns, protocolKey, policy.ObjectMeta.Name)
+				if err := writeNetworkPolicyToFile(policy, nsDirPath, filename); err != nil {
+					continue
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func writePolicyToFile(policy *policyType.KubeArmorPolicy, nsDirPath, filename string) error {
+	yamlStr := kubearmorPolicyToString(policy)
+
+	fmt.Println(yamlStr) // Print to terminal
+
+	filePath := filepath.Join(nsDirPath, filename)
+	return os.WriteFile(filePath, []byte(yamlStr), 0644)
+}
+
+func writeNetworkPolicyToFile(policy *networkingv1.NetworkPolicy, nsDirPath, filename string) error {
+	yamlStr := networkPolicyToString(policy)
+
+	fmt.Println(yamlStr) // Print to terminal
+
+	filePath := filepath.Join(nsDirPath, filename)
+	return os.WriteFile(filePath, []byte(yamlStr+"---\n"), 0644) // Appending '---\n' at the end of each policy
+}

--- a/pkg/discover/parsearg.go
+++ b/pkg/discover/parsearg.go
@@ -13,6 +13,7 @@ import (
 type Options struct {
 	GRPC           string   `flag:"grpc"`
 	Format         string   `flag:"format"`
+	Dump           bool     `flag:"dump"`
 	Kind           []string `flag:"policy"`
 	Namespace      []string `flag:"namespace"`
 	Labels         []string `flag:"labels"`
@@ -53,6 +54,9 @@ func ProcessArgs(rawArgs string) (*Options, error) {
 				return nil, wrapErr(fmt.Errorf("invalid format"))
 			}
 			parsed.Format, err = parser.ParseString(rawArgs, flag)
+
+		case flag == "dump":
+			parsed.Dump = true
 
 		case flag == "policy" || flag == "p":
 			parsed.Kind, err = parser.ParseStringSlice(rawArgs, flag)

--- a/pkg/discover/policies.go
+++ b/pkg/discover/policies.go
@@ -444,11 +444,14 @@ func initializeProgressBar(totalCount int) *progressbar.ProgressBar {
 	bar := progressbar.NewOptions(
 		totalCount,
 		progressbar.OptionSetDescription("Processing policies..."),
-		progressbar.OptionSpinnerType(14),
-		progressbar.OptionFullWidth(),
-		progressbar.OptionSetPredictTime(false),
-		progressbar.OptionSetWidth(10),
+		progressbar.OptionSetRenderBlankState(true),
+		progressbar.OptionSpinnerType(9),
+		progressbar.OptionSetPredictTime(true),
 		progressbar.OptionClearOnFinish(),
+		progressbar.OptionSetElapsedTime(true),
+		progressbar.OptionShowCount(),
+		progressbar.OptionShowBytes(true),
+		progressbar.OptionShowIts(),
 	)
 	return bar
 }

--- a/pkg/discover/tui.go
+++ b/pkg/discover/tui.go
@@ -51,7 +51,7 @@ func StartTUI(pf *PolicyForest) {
 		SetDynamicColors(true)
 
 	navigationCues := tview.NewTextView().
-		SetText("Navigate: Arrows | Select: Enter | Exit: Q/Esc").
+		SetText("Navigate: Arrows | Select: Click | Exit: Q/Esc").
 		SetTextAlign(tview.AlignRight).
 		SetDynamicColors(true)
 

--- a/pkg/recommend/dump.go
+++ b/pkg/recommend/dump.go
@@ -1,0 +1,39 @@
+package recommend
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	policyType "github.com/accuknox/dev2/hardening/pkg/types"
+)
+
+func dump(bucket *PolicyBucket) error {
+	dirPath := "knoxctl_out/recommended"
+	if err := os.MkdirAll(dirPath, os.ModePerm); err != nil {
+		return fmt.Errorf("failed to create directory: %v", err)
+	}
+
+	for ns, attrBucket := range bucket.Namespaces {
+		nsDirPath := filepath.Join(dirPath, ns)
+		if err := os.MkdirAll(nsDirPath, os.ModePerm); err != nil {
+			return fmt.Errorf("failed to create namespace directory '%s': %v", nsDirPath, err)
+		}
+
+		allPolicies := getAllPoliciesInBucket(attrBucket)
+		for _, policy := range allPolicies {
+			filename := fmt.Sprintf("%s-%s.yaml", ns, policy.Metadata.Name)
+			if err := writeKubearmorPolicyToFile(policy, nsDirPath, filename); err != nil {
+				continue
+			}
+		}
+	}
+
+	return nil
+}
+
+func writeKubearmorPolicyToFile(policy *policyType.KubeArmorPolicy, nsDirPath, filename string) error {
+	yamlStr := policyToString(policy)
+	filePath := filepath.Join(nsDirPath, filename)
+	return os.WriteFile(filePath, []byte(yamlStr), 0644)
+}

--- a/pkg/recommend/parseargs.go
+++ b/pkg/recommend/parseargs.go
@@ -15,6 +15,7 @@ type Options struct {
 	Policy    []string `flag:"policy"`
 	Outdir    string   `flag:"out"`
 	Grpc      string   `flag:"gRPC"`
+	Dump      bool     `flag:"dump"`
 
 	NamespaceRegex []*regexp.Regexp
 	LabelsRegex    []*regexp.Regexp
@@ -67,6 +68,9 @@ func ProcessArgs(rawArgs string) (*Options, error) {
 		case flag == "labels" || flag == "l":
 			parsedOption.Labels, regexList, err = parser.ParseRegexSlice(values, rawArgs, flag)
 			parsedOption.LabelsRegex = regexList
+
+		case flag == "dump":
+			parsedOption.Dump = true
 
 		default:
 			return nil, wrapErr(fmt.Errorf("unknown flag: %v", flag))

--- a/pkg/recommend/policies.go
+++ b/pkg/recommend/policies.go
@@ -159,6 +159,12 @@ func getKaPolicy(c *k8s.Client, o *Options) ([]string, error) {
 	if bar != nil {
 		bar.Finish()
 	}
+
+	if o.Dump {
+		dump(policyBucket)
+		return nil, nil
+	}
+
 	StartTUI(policyBucket)
 	return data, nil
 }
@@ -182,11 +188,14 @@ func initializeProgressBar(totalCount int) *progressbar.ProgressBar {
 	bar := progressbar.NewOptions(
 		totalCount,
 		progressbar.OptionSetDescription("Processing policies..."),
-		progressbar.OptionSpinnerType(14),
-		progressbar.OptionFullWidth(),
-		progressbar.OptionSetPredictTime(false),
-		progressbar.OptionSetWidth(10),
+		progressbar.OptionSetRenderBlankState(true),
+		progressbar.OptionSpinnerType(9),
+		progressbar.OptionSetPredictTime(true),
 		progressbar.OptionClearOnFinish(),
+		progressbar.OptionSetElapsedTime(true),
+		progressbar.OptionShowCount(),
+		progressbar.OptionShowBytes(true),
+		progressbar.OptionShowIts(),
 	)
 	return bar
 }

--- a/pkg/recommend/tui.go
+++ b/pkg/recommend/tui.go
@@ -51,7 +51,7 @@ func StartTUI(pb *PolicyBucket) {
 		SetDynamicColors(true)
 
 	navigationCues := tview.NewTextView().
-		SetText("Navigate: Arrows | Select: Enter | Exit: Q/Esc").
+		SetText("Navigate: Arrows | Select: Click | Exit: Q/Esc").
 		SetTextAlign(tview.AlignRight).
 		SetDynamicColors(true)
 

--- a/pkg/summary/parseargs.go
+++ b/pkg/summary/parseargs.go
@@ -10,14 +10,17 @@ import (
 
 // Options Structure
 type Options struct {
-	GRPC         string
-	Labels       []string
-	Namespace    []string
-	Source       []string
-	Destination  []string
-	Operation    string
-	Format       string
-	RevDNSLookup bool // I dont really know how we integrate this
+	GRPC         string   `flag:"gRPC"`
+	Labels       []string `flag:"labels"`
+	Namespace    []string `flag:"namespace"`
+	Source       []string `flag:"source"`
+	Destination  []string `flag:"destination"`
+	Operation    string   `flag:"operation"`
+	View         string   `flag:"view"`
+	Outdir       string   `flag:"outdir"`
+	Dump         bool     `flag:"dump"`
+	Glance       bool     `flag:"glance"`
+	RevDNSLookup bool     // I dont really know how we integrate this
 
 	LabelsRegex      []*regexp.Regexp
 	NamespaceRegex   []*regexp.Regexp
@@ -61,8 +64,8 @@ func ProcessArgs(rawArgs string) (*Options, error) {
 		case flag == "operation" || flag == "o":
 			parsed.Operation, err = parser.ParseString(rawArgs, flag)
 
-		case flag == "format" || flag == "f":
-			parsed.Format, err = parser.ParseString(rawArgs, flag)
+		case flag == "view" || flag == "v":
+			parsed.View, err = parser.ParseString(rawArgs, flag)
 
 		case flag == "labels" || flag == "l":
 			parsed.Labels, regexList, err = parser.ParseRegexSlice(value, rawArgs, value)
@@ -80,8 +83,17 @@ func ProcessArgs(rawArgs string) (*Options, error) {
 			parsed.Destination, regexList, err = parser.ParseRegexSlice(value, rawArgs, flag)
 			parsed.DestinationRegex = regexList
 
+		case flag == "outdir" || flag == "o":
+			parsed.Outdir, err = parser.ParseString(rawArgs, flag)
+
 		case flag == "revdnslookup":
 			parsed.RevDNSLookup = true
+
+		case flag == "dump":
+			parsed.Dump = true
+
+		case flag == "glance":
+			parsed.Glance = true
 
 		default:
 			return nil, wrapErr(fmt.Errorf("unknown flag: %s", flag))

--- a/pkg/summary/table.go
+++ b/pkg/summary/table.go
@@ -5,7 +5,9 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/accuknox/dev2/api/grpc/v2/summary"
 	"github.com/olekukonko/tablewriter"
+	"github.com/schollz/progressbar/v3"
 )
 
 func displayWorkloadInTable(workload *Workload) {
@@ -16,25 +18,53 @@ func displayWorkloadInTable(workload *Workload) {
 }
 
 func displayClusterInTable(cluster *Cluster) {
-	table := tablewriter.NewWriter(os.Stdout)
-	table.SetHeader([]string{"Namespace", "Workload Type", "File Events", "Process Events", "Ingress Events", "Egress Events", "Bind Events"})
-
 	for nsName, namespace := range cluster.Namespaces {
 		for wtName, workloadType := range namespace.WorkloadTypes {
-			fileEvents := len(workloadType.Events.File)
-			processEvents := len(workloadType.Events.Process)
-			ingressEvents := len(workloadType.Events.Ingress)
-			egressEvents := len(workloadType.Events.Egress)
-			bindEvents := len(workloadType.Events.Bind)
+			displayEvents("File Events", tablewriter.NewWriter(os.Stdout), nsName, wtName, workloadType.Events.File)
+			displayEvents("Process Events", tablewriter.NewWriter(os.Stdout), nsName, wtName, workloadType.Events.Process)
+			displayEvents("Ingress Events", tablewriter.NewWriter(os.Stdout), nsName, wtName, workloadType.Events.Ingress)
+			displayEvents("Egress Events", tablewriter.NewWriter(os.Stdout), nsName, wtName, workloadType.Events.Egress)
+			displayEvents("Bind Events", tablewriter.NewWriter(os.Stdout), nsName, wtName, workloadType.Events.Bind)
+		}
+	}
+}
 
+func displayEvents(title string, table *tablewriter.Table, nsName string, wtName string, events interface{}) {
+	eventCount := getEventCount(events)
+	if eventCount == 0 {
+		return // Skip rendering if there are no events
+	}
+
+	fmt.Printf("%s for Namespace '%s', Workload Type '%s':\n", title, nsName, wtName)
+
+	switch e := events.(type) {
+	case []*summary.ProcessFileEvent:
+		table.SetHeader([]string{"Pod", "Container", "Image Name", "Source", "Destination", "Count", "Updated Time"})
+		for _, event := range e {
 			row := []string{
-				nsName,
-				wtName,
-				fmt.Sprintf("%d", fileEvents),
-				fmt.Sprintf("%d", processEvents),
-				fmt.Sprintf("%d", ingressEvents),
-				fmt.Sprintf("%d", egressEvents),
-				fmt.Sprintf("%d", bindEvents),
+				event.Pod,
+				event.Container.Name,
+				event.Container.Image,
+				event.Source,
+				event.Destination,
+				fmt.Sprintf("%d", event.Count),
+				fmt.Sprintf("%d", event.UpdatedTime),
+			}
+			table.Append(row)
+		}
+	case []*summary.NetworkEvent:
+		table.SetHeader([]string{"Pod", "Container", "Image Name", "IP", "Port", "Protocol", "Peer Domain Name", "Count", "Updated Time"})
+		for _, event := range e {
+			row := []string{
+				event.Pod,
+				event.Container.Name,
+				event.Container.Image,
+				event.Ip,
+				fmt.Sprintf("%d", event.Port),
+				event.Protocol,
+				event.PeerDomainName,
+				fmt.Sprintf("%d", event.Count),
+				fmt.Sprintf("%d", event.UpdatedTime),
 			}
 			table.Append(row)
 		}
@@ -45,7 +75,10 @@ func displayClusterInTable(cluster *Cluster) {
 }
 
 func writeTableToFile(workload *Workload) error {
-	outDir := "out"
+	fmt.Println()
+	fmt.Println("Writing summary to file...")
+
+	outDir := "knoxctl_out"
 	if err := os.MkdirAll(outDir, os.ModePerm); err != nil {
 		return fmt.Errorf("failed to create output directory: %w", err)
 	}
@@ -59,40 +92,113 @@ func writeTableToFile(workload *Workload) error {
 	}
 	defer file.Close()
 
+	totalProgressSteps := calculateTotalProgressSteps(workload)
+	bar := initializeProgressBar("Writing Summary to File...", totalProgressSteps)
 	for clusterName, cluster := range workload.Clusters {
 		fmt.Fprintf(file, "Cluster: %s\n", clusterName)
-		writeClusterToTable(cluster, file)
+		writeClusterToTable(cluster, file, bar)
 	}
 
 	fmt.Printf("Summary written to %s\n", filePath)
 	return nil
 }
 
-func writeClusterToTable(cluster *Cluster, file *os.File) {
-	table := tablewriter.NewWriter(file)
-	table.SetHeader([]string{"Namespace", "Workload Type", "File Events", "Process Events", "Ingress Events", "Egress Events", "Bind Events"})
-
+func writeClusterToTable(cluster *Cluster, file *os.File, bar *progressbar.ProgressBar) {
 	for nsName, namespace := range cluster.Namespaces {
 		for wtName, workloadType := range namespace.WorkloadTypes {
-			fileEvents := len(workloadType.Events.File)
-			processEvents := len(workloadType.Events.Process)
-			ingressEvents := len(workloadType.Events.Ingress)
-			egressEvents := len(workloadType.Events.Egress)
-			bindEvents := len(workloadType.Events.Bind)
+			writeEventsToFile("File Events", tablewriter.NewWriter(file), file, nsName, wtName, workloadType.Events.File, bar)
+			writeEventsToFile("Process Events", tablewriter.NewWriter(file), file, nsName, wtName, workloadType.Events.Process, bar)
+			writeEventsToFile("Ingress Events", tablewriter.NewWriter(file), file, nsName, wtName, workloadType.Events.Ingress, bar)
+			writeEventsToFile("Egress Events", tablewriter.NewWriter(file), file, nsName, wtName, workloadType.Events.Egress, bar)
+			writeEventsToFile("Bind Events", tablewriter.NewWriter(file), file, nsName, wtName, workloadType.Events.Bind, bar)
+		}
+	}
+}
 
+func writeEventsToFile(title string, table *tablewriter.Table, file *os.File, nsName string, wtName string, events interface{}, bar *progressbar.ProgressBar) {
+	eventCount := getEventCount(events)
+	if eventCount == 0 {
+		return // Skip rendering if there are no events
+	}
+
+	fmt.Fprintf(file, "%s for Namespace '%s', Workload Type '%s':\n", title, nsName, wtName)
+
+	switch e := events.(type) {
+	case []*summary.ProcessFileEvent:
+		table.SetHeader([]string{"Pod", "Container", "Image Name", "Source", "Destination", "Count", "Updated Time"})
+		for _, event := range e {
 			row := []string{
-				nsName,
-				wtName,
-				fmt.Sprintf("%d", fileEvents),
-				fmt.Sprintf("%d", processEvents),
-				fmt.Sprintf("%d", ingressEvents),
-				fmt.Sprintf("%d", egressEvents),
-				fmt.Sprintf("%d", bindEvents),
+				event.Pod,
+				event.Container.Name,
+				event.Container.Image,
+				event.Source,
+				event.Destination,
+				fmt.Sprintf("%d", event.Count),
+				fmt.Sprintf("%d", event.UpdatedTime),
+			}
+			table.Append(row)
+		}
+	case []*summary.NetworkEvent:
+		table.SetHeader([]string{"Pod", "Container", "Image Name", "IP", "Port", "Protocol", "Peer Domain Name", "Count", "Updated Time"})
+		for _, event := range e {
+			row := []string{
+				event.Pod,
+				event.Container.Name,
+				event.Container.Image,
+				event.Ip,
+				fmt.Sprintf("%d", event.Port),
+				event.Protocol,
+				event.PeerDomainName,
+				fmt.Sprintf("%d", event.Count),
+				fmt.Sprintf("%d", event.UpdatedTime),
 			}
 			table.Append(row)
 		}
 	}
 
+	bar.Add(1)
 	table.Render()
 	fmt.Fprintln(file)
+}
+
+func getEventCount(events interface{}) int {
+	switch e := events.(type) {
+	case []*summary.ProcessFileEvent:
+		return len(e)
+	case []*summary.NetworkEvent:
+		return len(e)
+	default:
+		return 0
+	}
+}
+
+func calculateTotalProgressSteps(workload *Workload) int {
+	total := 0
+	for _, cluster := range workload.Clusters {
+		for _, namespace := range cluster.Namespaces {
+			for _, workloadType := range namespace.WorkloadTypes {
+				total += getEventGroupCount(workloadType)
+			}
+		}
+	}
+	return total
+}
+
+func getEventGroupCount(workloadType *WorkloadType) int {
+	count := 0
+	eventGroups := []interface{}{
+		workloadType.Events.File,
+		workloadType.Events.Process,
+		workloadType.Events.Ingress,
+		workloadType.Events.Egress,
+		workloadType.Events.Bind,
+	}
+
+	for _, events := range eventGroups {
+		if getEventCount(events) > 0 {
+			count++
+		}
+	}
+
+	return count
 }


### PR DESCRIPTION
Multiple changes:
- Added dump flag which will write DE data out to 'knoxctl_out' directory (for recommend, discover, summary)
- TUI improvements for summary 
- Performance improvement for summary when connected to custom gRPC 
- Added a view flag to summary for table and json view 
- Added a glance flag to summary to get a quick glance over summary data  