### PR TITLE
chore(regex): remove delimiter

### DIFF
--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -1,6 +1,8 @@
 package common
 
 const (
+	SpecialRegexChars = `.*+?()|[]{}^$`
+
 	ServiceName       = "discovery-engine" // Subject to change
 	Port        int64 = 8090
 	DELabel           = "app=discovery-engine"

--- a/pkg/common/regex_test.go
+++ b/pkg/common/regex_test.go
@@ -274,7 +274,7 @@ func TestParseRegexSlice(t *testing.T) {
 
 	p := NewParser()
 	for _, test := range tests {
-		strResults, rgxResults, err := p.ParseRegexSlice(test.value, test.input, test.flagName)
+		strResults, rgxResults, err := p.ParseRegexSlice(test.value, test.flagName)
 
 		if (err != nil) != test.err {
 			t.Errorf("ParseRegexSlice() error = %v, wantErr %v", err, test.err)

--- a/pkg/discover/parsearg.go
+++ b/pkg/discover/parsearg.go
@@ -39,9 +39,9 @@ func ProcessArgs(rawArgs string) (*Options, error) {
 	}
 
 	for flag, value := range flags {
-		if strings.HasPrefix(value, "r:") && !isRegexAllowed(flag) {
+		if flag != "gRPC" && !isRegexAllowed(flag) && strings.ContainsAny(value, common.SpecialRegexChars) {
 			allowedFlags := getRegexAllowedFlags()
-			return nil, fmt.Errorf("regex is not allowed for the flag: %s, currently supported regex flags are: %s", flag, strings.Join(allowedFlags, ", "))
+			return nil, fmt.Errorf("found special regex characters: `%s`, regex is not allowed for the flag: %s, currently allowed flags are: %s", common.SpecialRegexChars, flag, strings.Join(allowedFlags, ", "))
 		}
 
 		var regexList []*regexp.Regexp
@@ -62,15 +62,15 @@ func ProcessArgs(rawArgs string) (*Options, error) {
 			parsed.Kind, err = parser.ParseStringSlice(rawArgs, flag)
 
 		case flag == "namespace" || flag == "n":
-			parsed.Namespace, regexList, err = parser.ParseRegexSlice(value, rawArgs, flag)
+			parsed.Namespace, regexList, err = parser.ParseRegexSlice(value, flag)
 			parsed.NamespaceRegex = regexList
 
 		case flag == "labels" || flag == "l":
-			parsed.Labels, regexList, err = parser.ParseRegexSlice(value, rawArgs, flag)
+			parsed.Labels, regexList, err = parser.ParseRegexSlice(value, flag)
 			parsed.LabelsRegex = regexList
 
 		case flag == "source" || flag == "s":
-			parsed.Source, regexList, err = parser.ParseRegexSlice(value, rawArgs, flag)
+			parsed.Source, regexList, err = parser.ParseRegexSlice(value, flag)
 			parsed.SourceRegex = regexList
 
 		case flag == "includenet":
@@ -85,6 +85,7 @@ func ProcessArgs(rawArgs string) (*Options, error) {
 			return nil, wrapErr(err)
 		}
 	}
+
 	return parsed, nil
 }
 

--- a/pkg/recommend/parseargs.go
+++ b/pkg/recommend/parseargs.go
@@ -37,9 +37,9 @@ func ProcessArgs(rawArgs string) (*Options, error) {
 	}
 
 	for flag, values := range flags {
-		if strings.HasPrefix(values, "r:") && !isRegexAllowed(flag) {
+		if flag != "gRPC" && !isRegexAllowed(flag) && strings.ContainsAny(values, common.SpecialRegexChars) {
 			allowedFlags := getRegexAllowedFlags()
-			return nil, fmt.Errorf("regex is not allowed for the flag: %s, currently allowed flags are: %s", flag, strings.Join(allowedFlags, ", "))
+			return nil, fmt.Errorf("found special regex characters: `%s`, regex is not allowed for the flag: %s, currently allowed flags are: %s", common.SpecialRegexChars, flag, strings.Join(allowedFlags, ", "))
 		}
 
 		var regexList []*regexp.Regexp
@@ -58,15 +58,15 @@ func ProcessArgs(rawArgs string) (*Options, error) {
 			parsedOption.SeveritySlice, err = parser.ParseInt(rawArgs, flag)
 
 		case flag == "namespace" || flag == "n":
-			parsedOption.Namespace, regexList, err = parser.ParseRegexSlice(values, rawArgs, flag)
+			parsedOption.Namespace, regexList, err = parser.ParseRegexSlice(values, flag)
 			parsedOption.NamespaceRegex = regexList
 
 		case flag == "tags" || flag == "t":
-			parsedOption.Tags, regexList, err = parser.ParseRegexSlice(values, rawArgs, flag)
+			parsedOption.Tags, regexList, err = parser.ParseRegexSlice(values, flag)
 			parsedOption.TagsRegex = regexList
 
 		case flag == "labels" || flag == "l":
-			parsedOption.Labels, regexList, err = parser.ParseRegexSlice(values, rawArgs, flag)
+			parsedOption.Labels, regexList, err = parser.ParseRegexSlice(values, flag)
 			parsedOption.LabelsRegex = regexList
 
 		case flag == "dump":

--- a/pkg/summary/parseargs.go
+++ b/pkg/summary/parseargs.go
@@ -41,6 +41,7 @@ func (o *Options) noFilters() bool {
 
 	return lr == 0 && nr == 0 && sr == 0 && dr == 0 && l == 0 && n == 0 && s == 0 && d == 0
 }
+
 func ProcessArgs(rawArgs string) (*Options, error) {
 	parsed := &Options{}
 	parser := common.NewParser()
@@ -51,9 +52,9 @@ func ProcessArgs(rawArgs string) (*Options, error) {
 	}
 
 	for flag, value := range flags {
-		if strings.HasPrefix(value, "r:") && !isRegexAllowed(flag) {
+		if flag != "gRPC" && !isRegexAllowed(flag) && strings.ContainsAny(value, common.SpecialRegexChars) {
 			allowedFlags := getRegexAllowedFlags()
-			return nil, fmt.Errorf("regex is not allowed for the flag: %s, currently supported regex flags are: %s", flag, strings.Join(allowedFlags, ", "))
+			return nil, fmt.Errorf("found special regex characters: `%s`, regex is not allowed for the flag: %s, currently allowed flags are: %s", common.SpecialRegexChars, flag, strings.Join(allowedFlags, ", "))
 		}
 
 		var regexList []*regexp.Regexp
@@ -68,19 +69,19 @@ func ProcessArgs(rawArgs string) (*Options, error) {
 			parsed.View, err = parser.ParseString(rawArgs, flag)
 
 		case flag == "labels" || flag == "l":
-			parsed.Labels, regexList, err = parser.ParseRegexSlice(value, rawArgs, value)
+			parsed.Labels, regexList, err = parser.ParseRegexSlice(value, value)
 			parsed.LabelsRegex = regexList
 
 		case flag == "namespace" || flag == "n":
-			parsed.Namespace, regexList, err = parser.ParseRegexSlice(value, rawArgs, flag)
+			parsed.Namespace, regexList, err = parser.ParseRegexSlice(value, flag)
 			parsed.NamespaceRegex = regexList
 
 		case flag == "source" || flag == "s":
-			parsed.Source, regexList, err = parser.ParseRegexSlice(value, rawArgs, flag)
+			parsed.Source, regexList, err = parser.ParseRegexSlice(value, flag)
 			parsed.SourceRegex = regexList
 
 		case flag == "destination" || flag == "d":
-			parsed.Destination, regexList, err = parser.ParseRegexSlice(value, rawArgs, flag)
+			parsed.Destination, regexList, err = parser.ParseRegexSlice(value, flag)
 			parsed.DestinationRegex = regexList
 
 		case flag == "outdir" || flag == "o":


### PR DESCRIPTION
This PR removes the regex delimiter that was used earlier `r:` to identify regex patterns. The changes done are mainly to accept string that does not have `r:` delimiter and we now check with `strings.ContainsAny(...)` function if the flag's value has any regex special characters. We further try to compile the regex pattern and if it doesn't compiles we fallback to literal string.

Currently these ASCII characters are in regex character set: `.*+?()|[]{}^$`

Before regex command would have looked like: `knoxctl summary -n r:'accuknox-*'`
After this change it would look like: `knoxctl summary -n 'accuknox-*'`