### PR TITLE
chore(bin-name): change to knoxctl

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,7 +1,7 @@
 project_name: accuknoxcli
 
 builds:
-  - binary: accuknoxcli
+  - binary: knoxctl
     goos:
       - darwin
       - linux


### PR DESCRIPTION
The binary name that is currently present in assets is `accuknoxcli` which gets reflected whenever we make a new release, it actually should be named as `knoxctl`.