### PR TITLE
feat(push-binaries): push binaries to public webpage

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -20,6 +20,10 @@ var installCmd = &cobra.Command{
 	Short: "Install Kubearmor, Discovery Engine and License",
 	Long:  `Discover applicable policies`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// Replace this message once install is in place
+		fmt.Println("We are still working on install command.")
+		return nil
+
 		// Installing Kubearmor
 		if err := installOptions.Env.CheckAndSetValidEnvironmentOption(cmd.Flag("env").Value.String()); err != nil {
 			return fmt.Errorf("error in checking environment option: %v", err)

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"github.com/accuknox/accuknox-cli-v2/pkg/push"
+	"github.com/spf13/cobra"
+)
+
+var pushOptions push.Options
+
+var pushCmd = &cobra.Command{
+	Use:   "push",
+	Short: "Push policies to knoxctl",
+	Long:  "Push policie to knoxctl, only for internal use.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := push.Push(&pushOptions); err != nil {
+			return err
+		}
+		return nil
+	},
+	Hidden: true,
+}
+
+func init() {
+	rootCmd.AddCommand(pushCmd)
+
+	pushCmd.Flags().StringVarP(&pushOptions.GitPATPath, "git-pat", "", "", "Path to git PAT file")
+}

--- a/cmd/selfupdate.go
+++ b/cmd/selfupdate.go
@@ -21,6 +21,7 @@ var selfUpdateCmd = &cobra.Command{
 		}
 		return nil
 	},
+	Hidden: true,
 }
 
 func init() {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -21,6 +21,7 @@ var versionCmd = &cobra.Command{
 		}
 		return nil
 	},
+	Hidden: true,
 }
 
 func init() {

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	k8s.io/apimachinery v0.28.3
 	k8s.io/cli-runtime v0.28.3
 	k8s.io/client-go v0.28.3
+	k8s.io/klog/v2 v2.100.1
 	sigs.k8s.io/yaml v1.4.0
 )
 
@@ -321,7 +322,6 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/component-base v0.28.3 // indirect
-	k8s.io/klog/v2 v2.100.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20230717233707-2695361300d9 // indirect
 	k8s.io/kubectl v0.28.3 // indirect
 	k8s.io/pod-security-admission v0.27.1 // indirect

--- a/pkg/push/push.go
+++ b/pkg/push/push.go
@@ -1,0 +1,253 @@
+package push
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/accuknox/accuknox-cli-v2/pkg/common"
+	"github.com/google/go-github/github"
+)
+
+type Options struct {
+	GitPATPath string
+}
+
+// WARNING: This has to be changed once Accuknox's webpage is up with a proper domain name.
+// we will change the repo to Accuknox and repoName to knoxctl-website
+const (
+	repoOwner = "swarit-pandey"
+	repoName  = "knoxctl.github.io"
+)
+
+func downloadReleaseAssets(client *github.Client, ctx context.Context, owner string, repo string, releaseTag string, tempDir string) error {
+	release, _, err := client.Repositories.GetReleaseByTag(ctx, owner, repo, releaseTag)
+	if err != nil {
+		return fmt.Errorf("failed to get release by tag: %w", err)
+	}
+
+	for _, asset := range release.Assets {
+		filePath := filepath.Join(tempDir, *asset.Name)
+		err := downloadAsset(client, ctx, owner, repo, *asset.ID, filePath)
+		if err != nil {
+			return fmt.Errorf("failed to download asset: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func downloadAsset(client *github.Client, ctx context.Context, owner string, repo string, assetID int64, filePath string) error {
+	reader, redURL, err := client.Repositories.DownloadReleaseAsset(ctx, owner, repo, assetID)
+	if err != nil {
+		return fmt.Errorf("error downloading asset: %v", err)
+	}
+
+	if redURL != "" {
+		_, err := url.ParseRequestURI(redURL)
+		if err != nil {
+			return fmt.Errorf("error parsing redirect URL: %v", err)
+		}
+
+		httpClient := &http.Client{
+			Timeout: time.Second * 30,
+		}
+
+		resp, err := httpClient.Get(redURL)
+		if err != nil {
+			return fmt.Errorf("error downloading asset: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("error downloading asset: %v", resp.Status)
+		}
+
+		reader = resp.Body
+	} else if reader == nil {
+		return fmt.Errorf("error downloading asset: reader is nil")
+	}
+
+	cleanedDestPath := filepath.Clean(filePath)
+	out, err := os.Create(cleanedDestPath)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, reader)
+	return err
+}
+
+func uploadBinaries(client *github.Client, ctx context.Context, tempDir string) error {
+	files, err := os.ReadDir(tempDir)
+	if err != nil {
+		return fmt.Errorf("failed to read tempDir: %w", err)
+	}
+
+	var latestVersion string
+	for _, file := range files {
+		parts := strings.Split(file.Name(), "_") // format: accuknoxcli_<version>_<file-related-info>
+		if len(parts) > 1 {
+			latestVersion = strings.TrimPrefix(parts[1], ".tar.gz")
+			break
+		}
+	}
+
+	if latestVersion != "" {
+		fmt.Printf("Release version found: [%s]\n", latestVersion)
+		err = updateVersionFile(client, ctx, latestVersion)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = filepath.Walk(tempDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return fmt.Errorf("error walking the path: %w", err)
+		}
+
+		if !info.IsDir() && info.Size() > 0 {
+			cleanedPath := filepath.Clean(path)
+			file, openErr := os.Open(cleanedPath)
+			if openErr != nil {
+				return fmt.Errorf("failed to open file: %w", openErr)
+			}
+			defer file.Close()
+
+			content, readErr := io.ReadAll(file)
+			if readErr != nil {
+				return fmt.Errorf("failed to read file: %w", readErr)
+			}
+
+			repoPath := "static/binaries/" + info.Name() // this should go in static/binaries to make sure the binaries are downloadable
+
+			fileContent, _, _, err := client.Repositories.GetContents(ctx, repoOwner, repoName, repoPath, &github.RepositoryContentGetOptions{})
+			var sha string
+			if err == nil && fileContent != nil {
+				sha = *fileContent.SHA
+			}
+
+			// if branch is write protected we might have to change this
+			opts := &github.RepositoryContentFileOptions{
+				Message: github.String("chore(bin): upload/update binary file"),
+				Content: content,
+				Branch:  github.String("main"),
+				SHA:     &sha,
+			}
+
+			_, _, err = client.Repositories.CreateFile(ctx, repoOwner, repoName, repoPath, opts)
+			if err != nil {
+				fmt.Printf("failed to upload file: %v", err)
+			} else {
+				fmt.Printf("Uploaded %s to repository path %s\n", info.Name(), repoPath)
+			}
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("error in uploading file: %w", err)
+	}
+
+	t := time.Now()
+	formattedTime := t.Format("2006-01-02 15:04:05")
+	fmt.Printf("Artifacts uploaded [time: %v]\n", formattedTime)
+	return nil
+}
+
+func handleAssetsTransfer(gitPAT string) error {
+	ctx := context.Background()
+	client, err := common.SetupGitHubClient(gitPAT, ctx)
+	if err != nil {
+		return fmt.Errorf("failed to setup GitHub client: %w", err)
+	}
+
+	tempDir, err := os.MkdirTemp("", "knoxctl_assets")
+	if err != nil {
+		return fmt.Errorf("failed to create temp directory: %w", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	releaseTag, err := common.GetLatestVersion(client, ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get latest version: %w", err)
+	}
+
+	err = downloadReleaseAssets(client, ctx, common.AccuknoxGithub, common.AccuknoxCLIRepo, releaseTag, tempDir)
+	if err != nil {
+		return fmt.Errorf("failed to download release assets: %w", err)
+	}
+
+	_, err = os.ReadDir(tempDir)
+	if err != nil {
+		return fmt.Errorf("failed to list tempDir contents: %w", err)
+	}
+
+	err = uploadBinaries(client, ctx, tempDir)
+	if err != nil {
+		return fmt.Errorf("failed to upload binaries: %w", err)
+	}
+	return nil
+}
+
+// Push will push the GitHub artifacts to knoxctl website, this
+// subcommand requires a valid GitHub PAT and is only accessible
+// to an internal Accuknox member.
+func Push(options *Options) error {
+	if options.GitPATPath == "" {
+		return errors.New("empty Git PAT path")
+	}
+
+	gitPAT, err := readGitKey(options.GitPATPath)
+	if err != nil {
+		return err
+	}
+
+	return handleAssetsTransfer(gitPAT)
+}
+
+func readGitKey(path string) (string, error) {
+	cleanedPath := filepath.Clean(path)
+
+	keyBytes, err := os.ReadFile(cleanedPath)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(string(keyBytes)), nil
+}
+
+func updateVersionFile(client *github.Client, ctx context.Context, version string) error {
+	path := "static/version/latest-version.txt"
+
+	fileContent, _, _, err := client.Repositories.GetContents(ctx, repoOwner, repoName, path, &github.RepositoryContentGetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to fetch current file SHA: %w", err)
+	}
+	sha := *fileContent.SHA
+
+	content := []byte(version)
+	opts := &github.RepositoryContentFileOptions{
+		Message: github.String("update(version): update version"),
+		Content: content,
+		SHA:     &sha,
+		Branch:  github.String("main"),
+	}
+
+	_, _, err = client.Repositories.UpdateFile(ctx, repoOwner, repoName, path, opts)
+	if err != nil {
+		return fmt.Errorf("failed to update the file: %w", err)
+	}
+
+	fmt.Printf("Updated version in knoxctl webpage repo [%s]\n", version)
+	return nil
+}

--- a/pkg/summary/tui.go
+++ b/pkg/summary/tui.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
+	"k8s.io/klog/v2"
 )
 
 func StartTUI(workload *Workload) {
@@ -95,7 +96,7 @@ func StartTUI(workload *Workload) {
 		}()
 
 		namespaceTree.GetRoot().ClearChildren()
-
+		klog.Infof("Selected cluster: %s", workload.Clusters[mainText])
 		populateNamespaceTree(namespaceTree, workload.Clusters[mainText], mainText, detailsView, eventDetailsView)
 		app.SetFocus(namespaceTree)
 	})
@@ -147,12 +148,12 @@ func StartTUI(workload *Workload) {
 }
 
 func populateNamespaceTree(treeView *tview.TreeView, cluster *Cluster, clusterName string, detailsView, eventDetailsView *tview.TextView) {
-	sortedNamespaceNames := sortNamespacesByEvents(cluster)
+	// sortedNamespaceNames := sortNamespacesByEvents(cluster)
 
 	root := tview.NewTreeNode(clusterName).SetSelectable(false).SetColor(tcell.ColorGreen)
 	treeView.SetRoot(root)
 
-	for _, nsName := range sortedNamespaceNames {
+	for nsName := range cluster.Namespaces {
 		ns := cluster.Namespaces[nsName]
 		nsNode := tview.NewTreeNode(nsName).SetSelectable(false).SetColor(tcell.ColorYellow)
 		root.AddChild(nsNode)


### PR DESCRIPTION
Changes: 
- Added push command that requires GIT-PAT to push the binaries to knoxctl webpage.
- Disabled install command for now (will not try to install anything, and return without error).
- Hid all the commands by default that need GIT-PAT. Internal engineers still be able to use those commands with their GIT-PAT (self-update, version, push).
- We also push the value of current release version to the knoxctl web repo. 