### PR TITLE
fix(version): display version without access token

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -8,15 +8,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var option version.Option
-
 // versionCmd represents the get command
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Display version information",
 	Long:  `Display version information`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := version.PrintVersion(client, option.GitPATPath); err != nil {
+		if err := version.PrintVersion(client); err != nil {
 			return err
 		}
 		return nil
@@ -25,5 +23,4 @@ var versionCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(versionCmd)
-	versionCmd.Flags().StringVar(&option.GitPATPath, "git-pat", "", "Print client version")
 }

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,6 @@ require (
 	github.com/accuknox/dev2/discover v0.0.0-20231026051927-56fe5412ae0d
 	github.com/accuknox/dev2/hardening v0.0.0-20231026051927-56fe5412ae0d
 	github.com/clarketm/json v1.17.1
-	github.com/fatih/color v1.15.0
 	github.com/gdamore/tcell/v2 v2.6.0
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/jedib0t/go-pretty v4.3.0+incompatible
@@ -131,6 +130,7 @@ require (
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/evertras/bubble-table v0.15.2 // indirect
+	github.com/fatih/color v1.15.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/gdamore/encoding v1.0.0 // indirect
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32 // indirect


### PR DESCRIPTION
Changes:
- Eariler to get the release version of knoxctl we needed to have GitHub PAT (Personal Access Token)
- Now we push the release version directly to knoxctl webpage
- And get the version from knoxctl's webpage