### PR TITLE
feat(ci): add workflow to release binaries

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,3 +48,33 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Fetch Tag Name
+        id: get_tag
+        run: echo "::set-output name=TAG_NAME::$(git describe --tags --abbrev=0)"
+      
+      - name: Checkout knoxctl-website Repository
+        uses: actions/checkout@v3
+        with:
+          repository: accuknox/knoxctl-website
+          token: ${{ secrets.AK_PAT_REPO_SCOPE }}
+          path: knoxctl-website
+          ref: main
+
+      - name: Update latest version file 
+        run: |
+          echo "${{ steps.get_tag.outputs.TAG_NAME }}" > knoxctl-website/static/version/latest_version.txt
+          cd knoxctl-website
+          git config user.name "accuknox-user"
+          git config user.email "devops.alerts@accuknox.com"
+          git add static/version/latest_version.txt
+          git commit -m "[knoxctl-ci-bot] Update latest version to ${{ steps.get_tag.outputs.TAG_NAME }}"
+          git push origin main
+
+      - name: Upload binaries to knoxctl-website
+        run: |
+          cp -r dist/* knoxctl-website/static/binaries/
+          cd knoxctl-website
+          git add static/binaries/
+          git commit -m "[knoxctl-ci-bot] Add binaries for version ${{ steps.get_tag.outputs.TAG_NAME }}"
+          git push origin main 


### PR DESCRIPTION
Extended the release workflow to push 
- Latest release tag
- Binaries (and other artifacts) 

to knoxctl-website. 

This makes sure that with every release knoxctl's web page has latest artifacts and information, without any manual intervention (such as raising a new PR). 