### PR TITLE
chore(onboard): spire cert URL handling

### DIFF
--- a/cmd/onboard-vm-cp-node.go
+++ b/cmd/onboard-vm-cp-node.go
@@ -15,6 +15,9 @@ var (
 	ppsHost     string
 	knoxGateway string
 
+	// non-essential
+	spireTrustBundle string
+
 	// cp-node only images
 	kubeArmorRelayServerImage string
 	siaImage                  string
@@ -33,7 +36,7 @@ var cpNodeCmd = &cobra.Command{
 			return fmt.Errorf("Failed to create cluster config: %s", err.Error())
 		}
 
-		onboardConfig := onboard.InitCPNodeConfig(*clusterConfig, joinToken, spireHost, ppsHost, knoxGateway)
+		onboardConfig := onboard.InitCPNodeConfig(*clusterConfig, joinToken, spireHost, ppsHost, knoxGateway, spireTrustBundle)
 
 		err = onboardConfig.InitializeControlPlane()
 		if err != nil {
@@ -56,6 +59,8 @@ func init() {
 	cpNodeCmd.PersistentFlags().StringVar(&spireHost, "spire-host", "", "address of spire-host to connect for authenticating with accuknox SaaS")
 	cpNodeCmd.PersistentFlags().StringVar(&ppsHost, "pps-host", "", "address of policy-provider-service to connect with for receiving policies")
 	cpNodeCmd.PersistentFlags().StringVar(&knoxGateway, "knox-gateway", "", "address of knox-gateway to connect with for pushing telemetry data")
+
+	cpNodeCmd.PersistentFlags().StringVar(&spireTrustBundle, "spire-trust-bundle-addr", "", "address of spire trust bundle (CA cert for accuknox spire-server)")
 
 	cpNodeCmd.PersistentFlags().StringVar(&nodeAddr, "cp-node-addr", "", "address of control plane node for generating join command")
 

--- a/pkg/onboard/configObjects.go
+++ b/pkg/onboard/configObjects.go
@@ -16,4 +16,12 @@ var (
 
 	//go:embed templates/spire-agent.conf
 	spireAgentConfig string
+
+	spireTrustBundleURLMap = map[string]string{
+		"dev":     "https://accuknox-dev-cert-spire.s3.us-east-2.amazonaws.com/ca.crt",
+		"stage":   "https://accuknox-stage-cert-spire.s3.us-east-2.amazonaws.com/ca.crt",
+		"demo":    "https://accuknox-demo-cert-spire.s3.us-east-2.amazonaws.com/ca.crt",
+		"prod":    "https://accuknox-prod-cert-spire.s3.us-east-2.amazonaws.com/ca.crt",
+		"xcitium": "https://accuknox-spire.s3.amazonaws.com/certs/xcitium/certificate.crt",
+	}
 )

--- a/pkg/onboard/templates/docker-compose_cp-node.yaml
+++ b/pkg/onboard/templates/docker-compose_cp-node.yaml
@@ -10,8 +10,11 @@ services:
       - "/etc/spire/conf/agent.conf"
       - "-expandEnv"
     volumes:
+      # for SPIRE config
       - "{{.ConfigPath}}:/etc"
+      # for SPIRE socket
       - "/var/run/:/var/run/"
+      # for spire SVID persistence
       - "/var/lib/spire/agent:/var/lib/spire/agent"
     labels:
       app: spire-agent
@@ -226,6 +229,7 @@ services:
       app: policy-enforcement-agent
     volumes:
       - "{{.ConfigPath}}:/opt"
+      # for spire socket
       - "/var/run:/var/run:ro"
     restart: on-failure:4
     ports:

--- a/pkg/onboard/utils.go
+++ b/pkg/onboard/utils.go
@@ -2,6 +2,7 @@ package onboard
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -208,6 +209,10 @@ func ExecComposeCommand(setStdOut, dryRun bool, tryCmd string, args ...string) (
 
 		err := composeCmd.Run()
 		if err != nil {
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				return "", errors.New(string(exitErr.Stderr))
+			}
+
 			return "", err
 		}
 
@@ -233,6 +238,9 @@ func (cc *ClusterConfig) validateEnv() error {
 	serverVersionCmd := exec.Command("docker", "version", "-f", "{{.Server.Version}}")
 	serverVersion, err := serverVersionCmd.Output()
 	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return errors.New(string(exitErr.Stderr))
+		}
 		return err
 	}
 


### PR DESCRIPTION
### Description
- Adds SPIRE CA certs for environments other than dev and stage
- Adds handling for not erroring if `spire-host` is unknown (we use insecure bootstrap)
- Adds handling for specifying a cert through the `--spire-trust-bundle-addr` flag
- Misc. enhancement: Improved error handling for docker exec