### PR TITLE
chore: some bug fixes

### DIFF
--- a/pkg/onboard/templates/docker-compose_cp-node.yaml
+++ b/pkg/onboard/templates/docker-compose_cp-node.yaml
@@ -131,7 +131,8 @@ services:
       - "kubearmor-only"
       - "kubearmor"
     depends_on:
-      - kubearmor
+      kubearmor:
+        condition: service_started
     container_name: kubearmor-vm-adapter
     image: "{{.KubeArmorVMAdapterImage}}"
     command:
@@ -156,6 +157,8 @@ services:
       wait-for-it:
         condition: service_completed_successfully
       kubearmor:
+        condition: service_started
+      kubearmor-vm-adapter:
         condition: service_started
     container_name: shared-informer-agent
     image: "{{.SIAImage}}"

--- a/pkg/onboard/templates/docker-compose_node.yaml
+++ b/pkg/onboard/templates/docker-compose_node.yaml
@@ -65,7 +65,8 @@ services:
       - "kubearmor-only"
       - "kubearmor"
     depends_on:
-      - kubearmor
+      kubearmor:
+        condition: service_started
     container_name: kubearmor-vm-adapter
     image: "{{.KubeArmorVMAdapterImage}}"
     command:

--- a/pkg/onboard/utils.go
+++ b/pkg/onboard/utils.go
@@ -107,9 +107,12 @@ func copyOrGenerateFile(userConfigDir, dirPath, filePath string, tempFuncs templ
 		return "", err
 	}
 
-	// fullFilePath contains the path to configDir - hard coding paths won't be efficient
+	// ignoring G304 - fullFilePath contains the path to configDir - hard coding
+	// paths won't be efficient
+	// ignoring G302 - if containers are run by the root user, members of the
+	// docker group should be able to read the files
 	// overwrite files if need
-	resultFile, err := os.OpenFile(fullFilePath, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0644) // #nosec G304
+	resultFile, err := os.OpenFile(fullFilePath, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0644) // #nosec G304 G302
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Signed-off-by: Rudraksh Pareek <rudraksh@accuknox.com>

Description:
- The file perms for agent's config files were 0600 earlier. Changed it to 0644 (`-rw-r--r--`) so that user in the container can read files created by host root users.
- This wasn't discovered earlier as tests/validation were mainly done with a normal user who were a part of the `docker` group already so containers run by them could read files even with 0600.