### PR TITLE
chore: update templates to run SPIRE as privileged

### DIFF
--- a/pkg/onboard/onboard.go
+++ b/pkg/onboard/onboard.go
@@ -111,7 +111,7 @@ func CreateClusterConfig(clusterType ClusterType, userConfigPath, kubearmorVersi
 // prints join command - currently only with the default ports
 // TODO: handle complex configuration
 func (cc *ClusterConfig) PrintJoinCommand() {
-	command := fmt.Sprintf("knoxctl onboard vm node --cp-addr=%s", cc.CPNodeAddr)
+	command := fmt.Sprintf("knoxctl onboard vm node --cp-node-addr=%s", cc.CPNodeAddr)
 
 	fmt.Println(command)
 }

--- a/pkg/onboard/templates/docker-compose_cp-node.yaml
+++ b/pkg/onboard/templates/docker-compose_cp-node.yaml
@@ -27,6 +27,7 @@ services:
       - "9091:9091"
       - "9090:9090"
     pid: "host"
+    privileged: true
 
   wait-for-it:
     container_name: wait-for-it


### PR DESCRIPTION
### Description

- Certain environments don't give enough capabilities like SYS_PTRACE which is required by SPIRE for workload attestation using PIDs. Thus, we run SPIRE as a privileged container
- Minute detail enhancement.