### PR TITLE
chore(config): don't push logs to alerts queue; docker compose version compat

### DIFF
--- a/cmd/onboard-vm-cp-node.go
+++ b/cmd/onboard-vm-cp-node.go
@@ -17,6 +17,7 @@ var (
 
 	// non-essential
 	spireTrustBundle string
+	enableLogs       bool
 
 	// cp-node only images
 	kubeArmorRelayServerImage string
@@ -36,7 +37,7 @@ var cpNodeCmd = &cobra.Command{
 			return fmt.Errorf("Failed to create cluster config: %s", err.Error())
 		}
 
-		onboardConfig := onboard.InitCPNodeConfig(*clusterConfig, joinToken, spireHost, ppsHost, knoxGateway, spireTrustBundle)
+		onboardConfig := onboard.InitCPNodeConfig(*clusterConfig, joinToken, spireHost, ppsHost, knoxGateway, spireTrustBundle, enableLogs)
 
 		err = onboardConfig.InitializeControlPlane()
 		if err != nil {
@@ -65,6 +66,8 @@ func init() {
 	cpNodeCmd.PersistentFlags().StringVar(&knoxGateway, "knox-gateway", "", "address of knox-gateway to connect with for pushing telemetry data")
 
 	cpNodeCmd.PersistentFlags().StringVar(&spireTrustBundle, "spire-trust-bundle-addr", "", "address of spire trust bundle (CA cert for accuknox spire-server)")
+
+	cpNodeCmd.PersistentFlags().BoolVar(&enableLogs, "enable-logs", false, "enable pushing logs from feeder service")
 
 	cpNodeCmd.PersistentFlags().StringVar(&nodeAddr, "cp-node-addr", "", "address of control plane node for generating join command")
 

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -56,8 +56,9 @@ const (
 	DefaultSIAImage           = "public.ecr.aws/k9v9d5v2/shared-informer-agent:"
 	DefaultFeederImage        = "public.ecr.aws/k9v9d5v2/feeder-service:"
 
-	MinDockerVersion        = "v19.0.3"
-	MinDockerComposeVersion = "v1.27.0"
+	MinDockerVersion                  = "v19.0.3"
+	MinDockerComposeVersion           = "v1.27.0"
+	MinDockerComposeWithWaitSupported = "v2.17.0"
 )
 
 var (

--- a/pkg/deboard/deboard.go
+++ b/pkg/deboard/deboard.go
@@ -21,7 +21,9 @@ func Deboard(nodeType onboard.NodeType, dryRun bool) (string, error) {
 		return configPath, err
 	}
 
-	composeCmd := onboard.GetComposeCommand()
+	composeCmd, composeVersion := onboard.GetComposeCommand()
+	fmt.Printf("Using %s version %s\n", composeCmd, composeVersion)
+
 	switch nodeType {
 	case onboard.NodeType_ControlPlane:
 		_, err = onboard.ExecComposeCommand(true, dryRun, composeCmd,

--- a/pkg/onboard/templates/docker-compose_cp-node.yaml
+++ b/pkg/onboard/templates/docker-compose_cp-node.yaml
@@ -219,7 +219,7 @@ services:
       - "KUBEARMOR_URL={{.RelayServerAddr}}"
       - "KUBEARMOR_PORT={{.RelayServerPort}}"
 
-      - "KMUX_LOGS_ENABLED=true"
+      - "KMUX_LOGS_ENABLED={{.EnableLogs}}"
       - "KMUX_CONFIG_PATH=/opt/feeder-service/kmux-config.yaml"
 
       - "SPIRE_AGENT_URL=unix:///var/run/spire/agent.sock"

--- a/pkg/onboard/templates/sia-config.yaml
+++ b/pkg/onboard/templates/sia-config.yaml
@@ -14,4 +14,4 @@ state-agent:
   port: 32769
 
 k8s:
-  enable:false
+  enable: false

--- a/pkg/onboard/types.go
+++ b/pkg/onboard/types.go
@@ -77,7 +77,8 @@ type ClusterConfig struct {
 	CIDR string
 
 	// internal
-	composeCmd string
+	composeCmd     string
+	composeVersion string
 }
 
 type InitConfig struct {
@@ -90,6 +91,7 @@ type InitConfig struct {
 
 	// advanced
 	SpireTrustBundleURL string
+	EnableLogs          bool
 
 	// internal
 	TCArgs TemplateConfigArgs
@@ -146,6 +148,7 @@ type TemplateConfigArgs struct {
 	// feeder service configuration
 	RelayServerAddr string
 	RelayServerPort string
+	EnableLogs      bool
 
 	// policy-enforcement-agent config
 	PPSHost string


### PR DESCRIPTION
- Only push alerts from feeder service by default.
- Use `--enable-logs` if this behaviour has to change.
- Misc. change w.r.t differences between docker compose versions