### PR TITLE
chore(CI): Fix release process for this repo

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,7 @@
 name: Release knoxctl
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - '*'
@@ -13,7 +14,7 @@ jobs:
   knoxctl-release:
     runs-on: ubuntu-latest
     env:
-      GOPRIVATE: github.com/accuknox/*
+      GOPRIVATE: github.com/accuknox/
       GH_ACCESS_TOKEN: ${{ secrets.AK_PAT_REPO_SCOPE }}
       GIT_KEY: ${{ secrets.GIT_KEY }}
     steps:
@@ -38,14 +39,13 @@ jobs:
           TOKEN: ${{ secrets.AK_PAT_REPO_SCOPE }}
         run: |
           git config --global url."https://${USER}:${TOKEN}@github.com".insteadOf "https://github.com"
-          
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:
           distribution: goreleaser
           version: latest
-          args: release --clean
+          args: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -53,41 +53,18 @@ jobs:
         id: get_tag
         run: echo "::set-output name=TAG_NAME::$(git describe --tags --abbrev=0)"
 
-      - name: Checkout knoxctl-website Repository
-        uses: actions/checkout@v3
+      # create release in knoxctl-website repo
+      - name: Create release of knoxctl-website repo
+        # recommended action by GitHub actions/create-release after archive
+        uses: softprops/action-gh-release@v2
         with:
+          name: "${{ steps.get_tag.outputs.tag }}"
+          body: "Release ${{ steps.get_tag.outputs.TAG_NAME }} for knoxctl a.k.a accuknox-cli."
           repository: accuknox/knoxctl-website
           token: ${{ secrets.AK_PAT_REPO_SCOPE }}
-          path: knoxctl-website
-          ref: main
-
-      - name: Update latest version file 
-        run: |
-          echo "${{ steps.get_tag.outputs.TAG_NAME }}" > knoxctl-website/static/version/latest_version.txt
-          cd knoxctl-website
-          git config user.name "accuknox-user"
-          git config user.email "devops.alerts@accuknox.com"
-          git add static/version/latest_version.txt
-          git commit -m "[knoxctl-ci-bot] Update latest version to ${{ steps.get_tag.outputs.TAG_NAME }}"
-          git push origin main
-      - name: Upload binaries to knoxctl-website
-        run: |
-          cp -r dist/* knoxctl-website/static/binaries/
-          cd knoxctl-website
-          git add static/binaries/
-          git commit -m "[knoxctl-ci-bot] Add binaries for version ${{ steps.get_tag.outputs.TAG_NAME }}"
-          git push origin main
-
-      # - name: Update version in index.md
-      #   run: |
-      #     LATEST_TAG=${{ steps.get_tag.outputs.TAG_NAME }}
-      #     LATEST_TAG=${LATEST_TAG#v}
-      #     FILE_PATH=knoxctl-website/content/docs/install/index.md
-      #     sed -i "s/accuknoxcli_[0-9]*\.[0-9]*\.[0-9]*_/accuknoxcli_${LATEST_TAG}_/g" $FILE_PATH
-      #
-      #     cd knoxctl-website
-      #     git config user.name "accuknox-user"
-      #     git config user.email "devops.alerts@accuknox.com"
-      #     git add content/docs/install/index.md
-      #     git commit -m "[knoxctl-ci-bot] Update installation guide to version $LATEST_TAG"
-      #     git push origin main
+          make_latest: true
+          files: |
+            dist/*.tar.gz
+            dist/*.txt
+            dist/*.cert
+            dist/*.sig

--- a/Makefile
+++ b/Makefile
@@ -69,3 +69,13 @@ endif
 .PHONY: test 
 test: 
 	./scripts/tests.sh
+
+.PHONY: local-release
+local-release: build
+ifeq (, $(shell which goreleaser))
+	@{ \
+	set -e ;\
+	go install github.com/goreleaser/goreleaser@latest ;\
+	}
+endif
+	cd $(CURDIR); VERSION=$(shell git describe --tags --always --dirty) goreleaser release --clean --skip=publish --skip=sign --skip=validate --snapshot

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,434 @@
+#!/usr/bin/env sh
+
+# THIS SCRIPT HAS BEEN ADAPTED FROM
+# https://github.com/KubeArmor/kubearmor-client/blob/main/install.sh
+
+set -e
+
+usage() {
+  this=$1
+  cat <<EOF
+$this: download go binaries for knoxctl a.k.a accuknox-cli-v2
+
+Usage: $this [-b] bindir [-d] [tag]
+	-b sets bindir or installation directory, Defaults to ./bin
+	-d turns on debug logging
+
+	[tag] is a tag from -
+	https://github.com/accuknox/knoxctl-website/releases
+
+	If tag is missing, then the latest will be used.
+
+EOF
+  exit 2
+}
+
+parse_args() {
+  #BINDIR is ./bin unless set be ENV
+  # over-ridden by flag below
+
+  BINDIR=${BINDIR:-./bin}
+  while getopts "b:dh?x" arg; do
+    case "$arg" in
+      b) BINDIR="$OPTARG" ;;
+      d) log_set_priority 10 ;;
+      h | \?) usage "$0" ;;
+      x) set -x ;;
+    esac
+  done
+  shift $((OPTIND - 1))
+  TAG=$1
+}
+
+# this function wraps all the destructive operations
+# if a curl|bash cuts off the end of the script due to
+# network, either nothing will happen or will syntax error
+# out preventing half-done work
+execute() {
+  tmpdir=$(mktemp -d)
+  log_debug "downloading files into ${tmpdir}"
+  http_download "${tmpdir}/${TARBALL}" "${TARBALL_URL}"
+  http_download "${tmpdir}/${CHECKSUM}" "${CHECKSUM_URL}"
+  hash_sha256_verify "${tmpdir}/${TARBALL}" "${tmpdir}/${CHECKSUM}"
+  srcdir="${tmpdir}"
+  (cd "${tmpdir}" && untar "${TARBALL}")
+  test ! -d "${BINDIR}" && install -d "${BINDIR}"
+  for binexe in $BINARIES; do
+    if [ "$OS" = "windows" ]; then
+      binexe="${binexe}.exe"
+    fi
+    install "${srcdir}/${binexe}" "${BINDIR}/"
+    log_info "installed ${BINDIR}/${binexe}"
+    log_info "knoxctl is installed in ${BINDIR}"
+    log_info "invoke ${BINDIR}/${binexe} or move knoxctl to your desired PATH"
+  done
+  rm -rf "${tmpdir}"
+}
+
+get_binaries() {
+  case "$PLATFORM" in
+    darwin/amd64) BINARIES="knoxctl" ;;
+    darwin/arm64) BINARIES="knoxctl" ;;
+    linux/amd64) BINARIES="knoxctl" ;;
+    linux/arm64) BINARIES="knoxctl" ;;
+    windows/amd64) BINARIES="knoxctl" ;;
+    windows/arm64) BINARIES="knoxctl" ;;
+    *)
+      log_crit "platform $PLATFORM is not supported.  Make sure this script is up-to-date and file request at https://github.com/${PREFIX}/issues/new"
+      exit 1
+      ;;
+  esac
+}
+
+# returns true if $1 is newer than $2
+# false otherwsie
+semver_compare() {
+	V1_MAJOR=$(echo "$1"| cut -d'.' -f 1)
+	V1_MINOR=$(echo "$1"| cut -d'.' -f 2)
+	V1_PATCH=$(echo "$1"| cut -d'.' -f 3)
+
+	V2_MAJOR=$(echo "$2"| cut -d'.' -f 1)
+	V2_MINOR=$(echo "$2"| cut -d'.' -f 2)
+	V2_PATCH=$(echo "$2"| cut -d'.' -f 3)
+
+	if ([ "${V1_MAJOR}" -gt "${V2_MAJOR}" ]) || \
+	([ "${V1_MAJOR}" -eq "${V2_MAJOR}" ] && [ "${V1_MINOR}" -gt "${V2_MINOR}" ]) || \
+	([ "${V1_MAJOR}" -eq "${V2_MAJOR}" ] && [ "${V1_MINOR}" -eq "${V2_MINOR}" ] && [ "${V1_PATCH}" -ge "${V2_PATCH}" ]); then
+		# true
+		return 0
+	fi
+
+	# false
+	return 1
+}
+
+tag_to_version() {
+	if [ -z "${TAG}" ]; then
+		# latest tag will always be fetched from GitHub
+		# as this script is added with v0.3.0
+		log_info "checking GitHub for latest tag"
+	else
+		# check GitHub only if provided tag greater than/equal to v0.3.0
+		if semver_compare "${TAG#v}" "0.3.0"; then
+			log_info "checking GitHub for tag '${TAG}'"
+		else
+			log_info "downloading from knoxctl.accuknox.com"
+			# if version starts with 'v', remove it
+			VERSION=${TAG#v}
+			return
+		fi
+	fi
+
+	REALTAG=$(github_release "$OWNER/$REPO" "${TAG}") && true
+
+	if test -z "$REALTAG"; then
+		log_crit "unable to find '${TAG}' - use 'latest' or see https://github.com/${PREFIX}/releases for details"
+		exit 1
+	fi
+	# if version starts with 'v', remove it
+	TAG="$REALTAG"
+	VERSION=${TAG#v}
+}
+
+adjust_format() {
+  # change format (tar.gz or zip) based on OS
+  true
+}
+
+adjust_os() {
+  # adjust archive name based on OS
+  true
+}
+
+adjust_arch() {
+  # adjust archive name based on ARCH
+  true
+}
+
+cat /dev/null <<EOF
+------------------------------------------------------------------------
+https://github.com/client9/shlib - portable posix shell functions
+Public domain - http://unlicense.org
+https://github.com/client9/shlib/blob/master/LICENSE.md
+but credit (and pull requests) appreciated.
+------------------------------------------------------------------------
+EOF
+is_command() {
+  command -v "$1" >/dev/null
+}
+echoerr() {
+  echo "$@" 1>&2
+}
+log_prefix() {
+  echo "$0"
+}
+_logp=6
+log_set_priority() {
+  _logp="$1"
+}
+log_priority() {
+  if test -z "$1"; then
+    echo "$_logp"
+    return
+  fi
+  [ "$1" -le "$_logp" ]
+}
+log_tag() {
+  case $1 in
+    0) echo "emerg" ;;
+    1) echo "alert" ;;
+    2) echo "crit" ;;
+    3) echo "err" ;;
+    4) echo "warning" ;;
+    5) echo "notice" ;;
+    6) echo "info" ;;
+    7) echo "debug" ;;
+    *) echo "$1" ;;
+  esac
+}
+log_debug() {
+  log_priority 7 || return 0
+  echoerr "$(log_prefix)" "$(log_tag 7)" "$@"
+}
+log_info() {
+  log_priority 6 || return 0
+  echoerr "$(log_prefix)" "$(log_tag 6)" "$@"
+}
+log_err() {
+  log_priority 3 || return 0
+  echoerr "$(log_prefix)" "$(log_tag 3)" "$@"
+}
+log_crit() {
+  log_priority 2 || return 0
+  echoerr "$(log_prefix)" "$(log_tag 2)" "$@"
+}
+uname_os() {
+  os=$(uname -s | tr '[:upper:]' '[:lower:]')
+  case "$os" in
+    cygwin_nt*) os="windows" ;;
+    mingw*) os="windows" ;;
+    msys_nt*) os="windows" ;;
+  esac
+  echo "$os"
+}
+uname_arch() {
+  arch=$(uname -m)
+  case $arch in
+    x86_64) arch="amd64" ;;
+    x86) arch="386" ;;
+    i686) arch="386" ;;
+    i386) arch="386" ;;
+    aarch64) arch="arm64" ;;
+    armv5*) arch="armv5" ;;
+    armv6*) arch="armv6" ;;
+    armv7*) arch="armv7" ;;
+  esac
+  echo ${arch}
+}
+uname_os_check() {
+  os=$(uname_os)
+  case "$os" in
+    darwin) return 0 ;;
+    dragonfly) return 0 ;;
+    freebsd) return 0 ;;
+    linux) return 0 ;;
+    android) return 0 ;;
+    nacl) return 0 ;;
+    netbsd) return 0 ;;
+    openbsd) return 0 ;;
+    plan9) return 0 ;;
+    solaris) return 0 ;;
+    windows) return 0 ;;
+  esac
+  log_crit "uname_os_check '$(uname -s)' got converted to '$os' which is not a GOOS value. Please file bug at https://github.com/client9/shlib"
+  return 1
+}
+uname_arch_check() {
+  arch=$(uname_arch)
+  case "$arch" in
+    386) return 0 ;;
+    amd64) return 0 ;;
+    arm64) return 0 ;;
+    armv5) return 0 ;;
+    armv6) return 0 ;;
+    armv7) return 0 ;;
+    ppc64) return 0 ;;
+    ppc64le) return 0 ;;
+    mips) return 0 ;;
+    mipsle) return 0 ;;
+    mips64) return 0 ;;
+    mips64le) return 0 ;;
+    s390x) return 0 ;;
+    amd64p32) return 0 ;;
+  esac
+  log_crit "uname_arch_check '$(uname -m)' got converted to '$arch' which is not a GOARCH value.  Please file bug report at https://github.com/client9/shlib"
+  return 1
+}
+untar() {
+  tarball=$1
+  case "${tarball}" in
+    *.tar.gz | *.tgz) tar --no-same-owner -xzf "${tarball}" ;;
+    *.tar) tar --no-same-owner -xf "${tarball}" ;;
+    *.zip) unzip "${tarball}" ;;
+    *)
+      log_err "untar unknown archive format for ${tarball}"
+      return 1
+      ;;
+  esac
+}
+http_download_curl() {
+  local_file=$1
+  source_url=$2
+  header=$3
+  if [ -z "$header" ]; then
+    code=$(curl -w '%{http_code}' -sL -o "$local_file" "$source_url")
+  else
+    code=$(curl -w '%{http_code}' -sL -H "$header" -o "$local_file" "$source_url")
+  fi
+  if [ "$code" != "200" ]; then
+    log_debug "http_download_curl received HTTP status $code"
+    return 1
+  fi
+  return 0
+}
+http_download_wget() {
+  local_file=$1
+  source_url=$2
+  header=$3
+  if [ -z "$header" ]; then
+    wget -q -O "$local_file" "$source_url"
+  else
+    wget -q --header "$header" -O "$local_file" "$source_url"
+  fi
+}
+http_download() {
+  log_debug "http_download $2"
+  if is_command curl; then
+    http_download_curl "$@"
+    return
+  elif is_command wget; then
+    http_download_wget "$@"
+    return
+  fi
+  log_crit "http_download unable to find wget or curl"
+  return 1
+}
+
+http_copy() {
+  tmp=$(mktemp)
+  http_download "${tmp}" "$1" "$2" || return 1
+  body=$(cat "$tmp")
+  rm -f "${tmp}"
+  echo "$body"
+}
+
+github_release() {
+  owner_repo=$1
+  version=$2
+  test -z "$version" && version="latest"
+  giturl="https://github.com/${owner_repo}/releases/${version}"
+  json=$(http_copy "$giturl" "Accept:application/json")
+  test -z "$json" && return 1
+  version=$(echo "$json" | tr -s '\n' ' ' | sed 's/.*"tag_name":"//' | sed 's/".*//')
+  test -z "$version" && return 1
+  echo "$version"
+}
+
+hash_sha256() {
+  TARGET=${1:-/dev/stdin}
+  if is_command gsha256sum; then
+    hash=$(gsha256sum "$TARGET") || return 1
+    echo "$hash" | cut -d ' ' -f 1
+  elif is_command sha256sum; then
+    hash=$(sha256sum "$TARGET") || return 1
+    echo "$hash" | cut -d ' ' -f 1
+  elif is_command shasum; then
+    hash=$(shasum -a 256 "$TARGET" 2>/dev/null) || return 1
+    echo "$hash" | cut -d ' ' -f 1
+  elif is_command openssl; then
+    hash=$(openssl -dst openssl dgst -sha256 "$TARGET") || return 1
+    echo "$hash" | cut -d ' ' -f a
+  else
+    log_crit "hash_sha256 unable to find command to compute sha-256 hash"
+    return 1
+  fi
+}
+
+hash_sha256_verify() {
+  TARGET=$1
+  checksums=$2
+  if [ -z "$checksums" ]; then
+    log_err "hash_sha256_verify checksum file not specified in arg2"
+    return 1
+  fi
+  BASENAME=${TARGET##*/}
+  want=$(grep "${BASENAME}" "${checksums}" 2>/dev/null | tr '\t' ' ' | cut -d ' ' -f 1)
+  if [ -z "$want" ]; then
+    log_err "hash_sha256_verify unable to find checksum for '${TARGET}' in '${checksums}'"
+    return 1
+  fi
+  got=$(hash_sha256 "$TARGET")
+  if [ "$want" != "$got" ]; then
+    log_err "hash_sha256_verify checksum for '$TARGET' did not verify ${want} vs $got"
+    return 1
+  fi
+}
+
+cat /dev/null <<EOF
+------------------------------------------------------------------------
+End of functions from https://github.com/client9/shlib
+------------------------------------------------------------------------
+EOF
+
+
+PROJECT_NAME="knoxctl"
+OWNER=accuknox
+REPO="knoxctl-website"
+BINARY=knoxctl
+FORMAT=tar.gz
+OS=$(uname_os)
+ARCH=$(uname_arch)
+PREFIX="$OWNER/$REPO"
+
+# use in logging routines
+log_prefix() {
+	echo "$PREFIX"
+}
+PLATFORM="${OS}/${ARCH}"
+
+S3_DOWNLOAD="https://knoxctl.accuknox.com/binaries"
+GITHUB_DOWNLOAD="https://github.com/${OWNER}/${REPO}/releases/download"
+
+uname_os_check "$OS"
+uname_arch_check "$ARCH"
+
+parse_args "$@"
+
+get_binaries
+
+tag_to_version
+
+adjust_format
+
+adjust_os
+
+adjust_arch
+
+log_info "found version: ${VERSION} for ${TAG}/${OS}/${ARCH}"
+
+NAME=${PROJECT_NAME}_${VERSION}_${OS}_${ARCH}
+TARBALL=${NAME}.${FORMAT}
+CHECKSUM=${PROJECT_NAME}_${VERSION}_checksums.txt
+
+if semver_compare "${VERSION}" "0.3.0";
+then
+	# version greater than/equal to 0.3.0 download from github releases
+	TARBALL_URL=${GITHUB_DOWNLOAD}/${TAG}/${TARBALL}
+	CHECKSUM_URL=${GITHUB_DOWNLOAD}/${TAG}/${CHECKSUM}
+else
+	# download from s3
+	TARBALL_URL=${S3_DOWNLOAD}/${TARBALL}
+	CHECKSUM_URL=${S3_DOWNLOAD}/${CHECKSUM}
+fi
+
+execute


### PR DESCRIPTION
### Description
- Release artifacts will now be pushed to accuknox/knoxctl-website
- Versioning would remain the same
- No binaires would be pushed as part of the Git tree
- An install script has been added as well which is adopted from karmor's and is backwards compatible with the releases made on S3

### Tests
- Tests for GH workflows - https://github.com/DelusionalOptimist/knoxctl-website/releases/tag/v0.3.2
- Above test release didn't have `cert` due to bad globbing pattern but it was added later.
- For testing the script, edit the `OWNER` in the script to delusionaloptimist instead of accuknox and run it with:
	```bash
	$ sudo ./install.sh -b /usr/local/bin
	```
	The above will install v0.3.2
	
- For downloading older versions (through S3):
	```bash
	$ sudo ./install.sh -b /usr/local/bin v0.2.13
	```
- If not used with `sudo` the script will install knoxctl in `$PWD/bin/` and leave it upto the user to add it to $PATH