### PR TITLE
chore: add dev2 to release.json

### DIFF
--- a/pkg/common/release.json
+++ b/pkg/common/release.json
@@ -416,5 +416,23 @@
     "pea_image": "accuknox/policy-enforcement-agent",
     "feeder_service_tag": "v0.2.4",
     "feeder_service_image": "accuknox/feeder-service"
+  },
+  "v0.5.11": {
+    "note": "Manually written. Timestamp wrong",
+    "creation_time": "1717354296",
+    "kubearmor_tag": "v1.3.8",
+    "kubearmor_relay_tag": "v0.0.4",
+    "kubearmor_vm_adapter_tag": "v0.0.6",
+    "spire_agent_tag": "v1.9.4",
+    "sia_tag": "v0.4.1",
+    "sia_image": "accuknox/shared-informer-agent",
+    "pea_tag": "v0.4.1",
+    "pea_image": "accuknox/policy-enforcement-agent",
+    "feeder_service_tag": "v0.5.2",
+    "feeder_service_image": "accuknox/feeder-service",
+    "discover_tag": "v0.1.25",
+    "discover_image": "accuknox/discovery-engine-discover",
+    "sumengine_tag": "v0.1.25",
+    "sumengine_image": "accuknox/discovery-engine-sumengine"
   }
 }


### PR DESCRIPTION
### Description
- Adds v0.5.11 - which points to discovery engine v0.1.25 and feeder v0.5.2

NOTE: The script will add dev2 to release.json only when discovery enginge v0.1.25 is present so that old deployments are not broken.