### PR TITLE
update release.json

### DIFF
--- a/pkg/common/release.json
+++ b/pkg/common/release.json
@@ -14,7 +14,9 @@
     "discover_tag": "v0.1.25",
     "discover_image": "accuknox/discovery-engine-discover",
     "sumengine_tag": "v0.1.25",
-    "sumengine_image": "accuknox/discovery-engine-sumengine"
+    "sumengine_image": "accuknox/discovery-engine-sumengine",
+    "hardening_image": "v0.1.27",
+    "hardening_tag": "accuknox/discovery-engine-hardening"
   },
   "v0.2.10": {
     "creation_time": "1707727047",
@@ -31,7 +33,9 @@
     "discover_tag": "v0.1.25",
     "discover_image": "accuknox/discovery-engine-discover",
     "sumengine_tag": "v0.1.25",
-    "sumengine_image": "accuknox/discovery-engine-sumengine"
+    "sumengine_image": "accuknox/discovery-engine-sumengine",
+    "hardening_image": "v0.1.27",
+    "hardening_tag": "accuknox/discovery-engine-hardening"
   },
   "v0.2.11": {
     "creation_time": "1708493489",
@@ -48,7 +52,9 @@
     "discover_tag": "v0.1.25",
     "discover_image": "accuknox/discovery-engine-discover",
     "sumengine_tag": "v0.1.25",
-    "sumengine_image": "accuknox/discovery-engine-sumengine"
+    "sumengine_image": "accuknox/discovery-engine-sumengine",
+    "hardening_image": "v0.1.27",
+    "hardening_tag": "accuknox/discovery-engine-hardening"
   },
   "v0.2.10-patch": {
     "creation_time": "1708578633",
@@ -65,7 +71,9 @@
     "discover_tag": "v0.1.25",
     "discover_image": "accuknox/discovery-engine-discover",
     "sumengine_tag": "v0.1.25",
-    "sumengine_image": "accuknox/discovery-engine-sumengine"
+    "sumengine_image": "accuknox/discovery-engine-sumengine",
+    "hardening_image": "v0.1.27",
+    "hardening_tag": "accuknox/discovery-engine-hardening"
   },
   "v0.3.0": {
     "creation_time": "1708590502",
@@ -82,7 +90,9 @@
     "discover_tag": "v0.1.25",
     "discover_image": "accuknox/discovery-engine-discover",
     "sumengine_tag": "v0.1.25",
-    "sumengine_image": "accuknox/discovery-engine-sumengine"
+    "sumengine_image": "accuknox/discovery-engine-sumengine",
+    "hardening_image": "v0.1.27",
+    "hardening_tag": "accuknox/discovery-engine-hardening"
   },
   "v0.3.1": {
     "creation_time": "1708607855",
@@ -99,7 +109,9 @@
     "discover_tag": "v0.1.25",
     "discover_image": "accuknox/discovery-engine-discover",
     "sumengine_tag": "v0.1.25",
-    "sumengine_image": "accuknox/discovery-engine-sumengine"
+    "sumengine_image": "accuknox/discovery-engine-sumengine",
+    "hardening_image": "v0.1.27",
+    "hardening_tag": "accuknox/discovery-engine-hardening"
   },
   "v0.3.3": {
     "creation_time": "1708971665",
@@ -116,7 +128,9 @@
     "discover_tag": "v0.1.25",
     "discover_image": "accuknox/discovery-engine-discover",
     "sumengine_tag": "v0.1.25",
-    "sumengine_image": "accuknox/discovery-engine-sumengine"
+    "sumengine_image": "accuknox/discovery-engine-sumengine",
+    "hardening_image": "v0.1.27",
+    "hardening_tag": "accuknox/discovery-engine-hardening"
   },
   "v0.4.0": {
     "creation_time": "1709207850",
@@ -133,7 +147,9 @@
     "discover_tag": "v0.1.25",
     "discover_image": "accuknox/discovery-engine-discover",
     "sumengine_tag": "v0.1.25",
-    "sumengine_image": "accuknox/discovery-engine-sumengine"
+    "sumengine_image": "accuknox/discovery-engine-sumengine",
+    "hardening_image": "v0.1.27",
+    "hardening_tag": "accuknox/discovery-engine-hardening"
   },
   "v0.4.0-rmq": {
     "creation_time": "1709317051",
@@ -150,7 +166,9 @@
     "discover_tag": "v0.1.25",
     "discover_image": "accuknox/discovery-engine-discover",
     "sumengine_tag": "v0.1.25",
-    "sumengine_image": "accuknox/discovery-engine-sumengine"
+    "sumengine_image": "accuknox/discovery-engine-sumengine",
+    "hardening_image": "v0.1.27",
+    "hardening_tag": "accuknox/discovery-engine-hardening"
   },
   "v0.3.2": {
     "creation_time": "1710157380",
@@ -167,7 +185,9 @@
     "discover_tag": "v0.1.25",
     "discover_image": "accuknox/discovery-engine-discover",
     "sumengine_tag": "v0.1.25",
-    "sumengine_image": "accuknox/discovery-engine-sumengine"
+    "sumengine_image": "accuknox/discovery-engine-sumengine",
+    "hardening_image": "v0.1.27",
+    "hardening_tag": "accuknox/discovery-engine-hardening"
   },
   "v0.2.12": {
     "creation_time": "1710175521",
@@ -184,7 +204,9 @@
     "discover_tag": "v0.1.25",
     "discover_image": "accuknox/discovery-engine-discover",
     "sumengine_tag": "v0.1.25",
-    "sumengine_image": "accuknox/discovery-engine-sumengine"
+    "sumengine_image": "accuknox/discovery-engine-sumengine",
+    "hardening_image": "v0.1.27",
+    "hardening_tag": "accuknox/discovery-engine-hardening"
   },
   "v0.5.0": {
     "creation_time": "1710913137",
@@ -201,7 +223,9 @@
     "discover_tag": "v0.1.25",
     "discover_image": "accuknox/discovery-engine-discover",
     "sumengine_tag": "v0.1.25",
-    "sumengine_image": "accuknox/discovery-engine-sumengine"
+    "sumengine_image": "accuknox/discovery-engine-sumengine",
+    "hardening_image": "v0.1.27",
+    "hardening_tag": "accuknox/discovery-engine-hardening"
   },
   "v0.4.0-patch": {
     "creation_time": "1710941843",
@@ -218,7 +242,9 @@
     "discover_tag": "v0.1.25",
     "discover_image": "accuknox/discovery-engine-discover",
     "sumengine_tag": "v0.1.25",
-    "sumengine_image": "accuknox/discovery-engine-sumengine"
+    "sumengine_image": "accuknox/discovery-engine-sumengine",
+    "hardening_image": "v0.1.27",
+    "hardening_tag": "accuknox/discovery-engine-hardening"
   },
   "v0.5.1": {
     "creation_time": "1711008943",
@@ -235,7 +261,9 @@
     "discover_tag": "v0.1.25",
     "discover_image": "accuknox/discovery-engine-discover",
     "sumengine_tag": "v0.1.25",
-    "sumengine_image": "accuknox/discovery-engine-sumengine"
+    "sumengine_image": "accuknox/discovery-engine-sumengine",
+    "hardening_image": "v0.1.27",
+    "hardening_tag": "accuknox/discovery-engine-hardening"
   },
   "v0.5.2": {
     "creation_time": "1711696981",
@@ -252,7 +280,9 @@
     "discover_tag": "v0.1.25",
     "discover_image": "accuknox/discovery-engine-discover",
     "sumengine_tag": "v0.1.25",
-    "sumengine_image": "accuknox/discovery-engine-sumengine"
+    "sumengine_image": "accuknox/discovery-engine-sumengine",
+    "hardening_image": "v0.1.27",
+    "hardening_tag": "accuknox/discovery-engine-hardening"
   },
   "v0.5.3": {
     "creation_time": "1712550507",
@@ -269,16 +299,18 @@
     "discover_tag": "v0.1.25",
     "discover_image": "accuknox/discovery-engine-discover",
     "sumengine_tag": "v0.1.25",
-    "sumengine_image": "accuknox/discovery-engine-sumengine"
+    "sumengine_image": "accuknox/discovery-engine-sumengine",
+    "hardening_image": "v0.1.27",
+    "hardening_tag": "accuknox/discovery-engine-hardening"
   },
   "v0.2.13": {
-    "note": "For systemd compatbility of SIA - v0.2.2, PEA - v0.2.2 and FS - v0.2.4. Doesn't deploy dev2",
+    "note": "For systemd compatbility PEA - v0.2.2 and FS - v0.2.4. For aggregation improvements SIA - v0.5.3",
     "creation_time": "1712733026",
     "kubearmor_tag": "v1.3.8",
     "kubearmor_relay_tag": "v0.0.4",
     "kubearmor_vm_adapter_tag": "v0.0.6",
     "spire_agent_tag": "v1.9.4",
-    "sia_tag": "v0.2.2",
+    "sia_tag": "v0.5.3",
     "sia_image": "accuknox/shared-informer-agent",
     "pea_tag": "v0.2.2",
     "pea_image": "accuknox/policy-enforcement-agent",
@@ -287,7 +319,9 @@
     "discover_tag": "v0.1.25",
     "discover_image": "accuknox/discovery-engine-discover",
     "sumengine_tag": "v0.1.25",
-    "sumengine_image": "accuknox/discovery-engine-sumengine"
+    "sumengine_image": "accuknox/discovery-engine-sumengine",
+    "hardening_image": "v0.1.27",
+    "hardening_tag": "accuknox/discovery-engine-hardening"
   },
   "v0.2.13-real": {
     "creation_time": "1712733026",
@@ -300,7 +334,13 @@
     "pea_tag": "v0.2.0",
     "pea_image": "accuknox/policy-enforcement-agent",
     "feeder_service_tag": "v0.2.0",
-    "feeder_service_image": "accuknox/feeder-service"
+    "feeder_service_image": "accuknox/feeder-service",
+    "discover_tag": "v0.1.25",
+    "discover_image": "accuknox/discovery-engine-discover",
+    "sumengine_tag": "v0.1.25",
+    "sumengine_image": "accuknox/discovery-engine-sumengine",
+    "hardening_image": "v0.1.27",
+    "hardening_tag": "accuknox/discovery-engine-hardening"
   },
   "v0.2.14": {
     "creation_time": "1713958879",
@@ -317,7 +357,9 @@
     "discover_tag": "v0.1.25",
     "discover_image": "accuknox/discovery-engine-discover",
     "sumengine_tag": "v0.1.25",
-    "sumengine_image": "accuknox/discovery-engine-sumengine"
+    "sumengine_image": "accuknox/discovery-engine-sumengine",
+    "hardening_image": "v0.1.27",
+    "hardening_tag": "accuknox/discovery-engine-hardening"
   },
   "v0.5.6": {
     "creation_time": "1715746528",
@@ -334,7 +376,9 @@
     "discover_tag": "v0.1.25",
     "discover_image": "accuknox/discovery-engine-discover",
     "sumengine_tag": "v0.1.25",
-    "sumengine_image": "accuknox/discovery-engine-sumengine"
+    "sumengine_image": "accuknox/discovery-engine-sumengine",
+    "hardening_image": "v0.1.27",
+    "hardening_tag": "accuknox/discovery-engine-hardening"
   },
   "v0.5.7": {
     "creation_time": "1715776575",
@@ -351,7 +395,9 @@
     "discover_tag": "v0.1.25",
     "discover_image": "accuknox/discovery-engine-discover",
     "sumengine_tag": "v0.1.25",
-    "sumengine_image": "accuknox/discovery-engine-sumengine"
+    "sumengine_image": "accuknox/discovery-engine-sumengine",
+    "hardening_image": "v0.1.27",
+    "hardening_tag": "accuknox/discovery-engine-hardening"
   },
   "v0.5.4": {
     "creation_time": "1715841557",
@@ -368,7 +414,9 @@
     "discover_tag": "v0.1.25",
     "discover_image": "accuknox/discovery-engine-discover",
     "sumengine_tag": "v0.1.25",
-    "sumengine_image": "accuknox/discovery-engine-sumengine"
+    "sumengine_image": "accuknox/discovery-engine-sumengine",
+    "hardening_image": "v0.1.27",
+    "hardening_tag": "accuknox/discovery-engine-hardening"
   },
   "v0.5.7-demo": {
     "creation_time": "1715855259",
@@ -385,7 +433,9 @@
     "discover_tag": "v0.1.25",
     "discover_image": "accuknox/discovery-engine-discover",
     "sumengine_tag": "v0.1.25",
-    "sumengine_image": "accuknox/discovery-engine-sumengine"
+    "sumengine_image": "accuknox/discovery-engine-sumengine",
+    "hardening_image": "v0.1.27",
+    "hardening_tag": "accuknox/discovery-engine-hardening"
   },
   "v0.5.5": {
     "creation_time": "1716197804",
@@ -402,7 +452,9 @@
     "discover_tag": "v0.1.25",
     "discover_image": "accuknox/discovery-engine-discover",
     "sumengine_tag": "v0.1.25",
-    "sumengine_image": "accuknox/discovery-engine-sumengine"
+    "sumengine_image": "accuknox/discovery-engine-sumengine",
+    "hardening_image": "v0.1.27",
+    "hardening_tag": "accuknox/discovery-engine-hardening"
   },
   "v0.5.7-patch": {
     "creation_time": "1716268584",
@@ -419,7 +471,9 @@
     "discover_tag": "v0.4.0-test",
     "discover_image": "accuknox/discovery-engine-discover",
     "sumengine_tag": "v0.4.0-test",
-    "sumengine_image": "accuknox/discovery-engine-sumengine"
+    "sumengine_image": "accuknox/discovery-engine-sumengine",
+    "hardening_image": "v0.4.0-test",
+    "hardening_tag": "accuknox/discovery-engine-hardening"
   },
   "v0.5.8": {
     "creation_time": "1716458085",
@@ -436,7 +490,9 @@
     "discover_tag": "v0.1.25",
     "discover_image": "accuknox/discovery-engine-discover",
     "sumengine_tag": "v0.1.25",
-    "sumengine_image": "accuknox/discovery-engine-sumengine"
+    "sumengine_image": "accuknox/discovery-engine-sumengine",
+    "hardening_image": "v0.1.27",
+    "hardening_tag": "accuknox/discovery-engine-hardening"
   },
   "v0.2.15": {
     "creation_time": "1716462789",
@@ -453,7 +509,9 @@
     "discover_tag": "v0.1.25",
     "discover_image": "accuknox/discovery-engine-discover",
     "sumengine_tag": "v0.1.25",
-    "sumengine_image": "accuknox/discovery-engine-sumengine"
+    "sumengine_image": "accuknox/discovery-engine-sumengine",
+    "hardening_image": "v0.1.27",
+    "hardening_tag": "accuknox/discovery-engine-hardening"
   },
   "v0.5.9": {
     "creation_time": "1716524949",
@@ -470,7 +528,9 @@
     "discover_tag": "v0.1.25",
     "discover_image": "accuknox/discovery-engine-discover",
     "sumengine_tag": "v0.1.25",
-    "sumengine_image": "accuknox/discovery-engine-sumengine"
+    "sumengine_image": "accuknox/discovery-engine-sumengine",
+    "hardening_image": "v0.1.27",
+    "hardening_tag": "accuknox/discovery-engine-hardening"
   },
   "v0.2.16": {
     "creation_time": "1716962905",
@@ -487,7 +547,9 @@
     "discover_tag": "v0.1.25",
     "discover_image": "accuknox/discovery-engine-discover",
     "sumengine_tag": "v0.1.25",
-    "sumengine_image": "accuknox/discovery-engine-sumengine"
+    "sumengine_image": "accuknox/discovery-engine-sumengine",
+    "hardening_image": "v0.1.27",
+    "hardening_tag": "accuknox/discovery-engine-hardening"
   },
   "v0.5.10": {
     "creation_time": "1717353729",
@@ -504,16 +566,18 @@
     "discover_tag": "v0.1.25",
     "discover_image": "accuknox/discovery-engine-discover",
     "sumengine_tag": "v0.1.25",
-    "sumengine_image": "accuknox/discovery-engine-sumengine"
+    "sumengine_image": "accuknox/discovery-engine-sumengine",
+    "hardening_image": "v0.1.27",
+    "hardening_tag": "accuknox/discovery-engine-hardening"
   },
   "v0.2.17": {
-    "note": "For systemd compatbility of SIA v0.2.2 and PEA v0.2.2. Doesn't deploy dev2.",
+    "note": "For systemd compatbility PEA - v0.2.2. For aggregation improvements SIA - v0.5.3",
     "creation_time": "1717354296",
     "kubearmor_tag": "v1.3.8",
     "kubearmor_relay_tag": "v0.0.4",
     "kubearmor_vm_adapter_tag": "v0.0.6",
     "spire_agent_tag": "v1.9.4",
-    "sia_tag": "v0.2.2",
+    "sia_tag": "v0.5.3",
     "sia_image": "accuknox/shared-informer-agent",
     "pea_tag": "v0.2.2",
     "pea_image": "accuknox/policy-enforcement-agent",
@@ -522,7 +586,9 @@
     "discover_tag": "v0.1.25",
     "discover_image": "accuknox/discovery-engine-discover",
     "sumengine_tag": "v0.1.25",
-    "sumengine_image": "accuknox/discovery-engine-sumengine"
+    "sumengine_image": "accuknox/discovery-engine-sumengine",
+    "hardening_image": "v0.1.27",
+    "hardening_tag": "accuknox/discovery-engine-hardening"
   },
   "v0.2.17-real": {
     "creation_time": "1717354296",
@@ -539,7 +605,9 @@
     "discover_tag": "v0.1.25",
     "discover_image": "accuknox/discovery-engine-discover",
     "sumengine_tag": "v0.1.25",
-    "sumengine_image": "accuknox/discovery-engine-sumengine"
+    "sumengine_image": "accuknox/discovery-engine-sumengine",
+    "hardening_image": "v0.1.27",
+    "hardening_tag": "accuknox/discovery-engine-hardening"
   },
   "v0.6.0": {
     "creation_time": "1718173582",
@@ -556,7 +624,9 @@
     "discover_tag": "v0.1.25",
     "discover_image": "accuknox/discovery-engine-discover",
     "sumengine_tag": "v0.1.25",
-    "sumengine_image": "accuknox/discovery-engine-sumengine"
+    "sumengine_image": "accuknox/discovery-engine-sumengine",
+    "hardening_image": "v0.1.27",
+    "hardening_tag": "accuknox/discovery-engine-hardening"
   },
   "v0.5.11": {
     "creation_time": "1718286696",
@@ -573,6 +643,65 @@
     "discover_tag": "v0.1.25",
     "discover_image": "accuknox/discovery-engine-discover",
     "sumengine_tag": "v0.1.25",
-    "sumengine_image": "accuknox/discovery-engine-sumengine"
+    "sumengine_image": "accuknox/discovery-engine-sumengine",
+    "hardening_image": "v0.1.27",
+    "hardening_tag": "accuknox/discovery-engine-hardening"
+  },
+  "v0.6.0-patch": {
+    "creation_time": "1718880620",
+    "kubearmor_tag": "v1.3.8",
+    "kubearmor_relay_tag": "v0.0.4",
+    "kubearmor_vm_adapter_tag": "v0.0.6",
+    "spire_agent_tag": "v1.9.4",
+    "sia_tag": "v0.5.0",
+    "sia_image": "accuknox/shared-informer-agent",
+    "pea_tag": "v0.4.1",
+    "pea_image": "accuknox/policy-enforcement-agent",
+    "feeder_service_tag": "v0.5.2",
+    "feeder_service_image": "accuknox/feeder-service",
+    "discover_tag": "v0.1.25",
+    "discover_image": "accuknox/discovery-engine-discover",
+    "sumengine_tag": "v0.1.25",
+    "sumengine_image": "accuknox/discovery-engine-sumengine",
+    "hardening_image": "v0.1.27",
+    "hardening_tag": "accuknox/discovery-engine-hardening"
+  },
+  "v0.6.1": {
+    "creation_time": "1718947352",
+    "kubearmor_tag": "v1.3.8",
+    "kubearmor_relay_tag": "v0.0.4",
+    "kubearmor_vm_adapter_tag": "v0.0.6",
+    "spire_agent_tag": "v1.9.4",
+    "sia_tag": "v0.5.0",
+    "sia_image": "accuknox/shared-informer-agent",
+    "pea_tag": "v0.4.1",
+    "pea_image": "accuknox/policy-enforcement-agent",
+    "feeder_service_tag": "v0.5.2",
+    "feeder_service_image": "accuknox/feeder-service",
+    "discover_tag": "v0.1.26",
+    "discover_image": "accuknox/discovery-engine-discover",
+    "sumengine_tag": "v0.1.26",
+    "sumengine_image": "accuknox/discovery-engine-sumengine",
+    "hardening_image": "v0.1.27",
+    "hardening_tag": "accuknox/discovery-engine-hardening"
+  },
+  "v0.6.2": {
+    "creation_time": "1719398139",
+    "kubearmor_tag": "v1.3.8",
+    "kubearmor_relay_tag": "v0.0.4",
+    "kubearmor_vm_adapter_tag": "v0.0.6",
+    "spire_agent_tag": "v1.9.4",
+    "sia_tag": "v0.5.2",
+    "sia_image": "accuknox/shared-informer-agent",
+    "pea_tag": "v0.4.2",
+    "pea_image": "accuknox/policy-enforcement-agent",
+    "feeder_service_tag": "v0.5.3",
+    "feeder_service_image": "accuknox/feeder-service",
+    "discover_tag": "v0.1.26",
+    "discover_image": "accuknox/discovery-engine-discover",
+    "sumengine_tag": "v0.1.26",
+    "sumengine_image": "accuknox/discovery-engine-sumengine",
+    "hardening_image": "v0.1.27",
+    "hardening_tag": "accuknox/discovery-engine-hardening"
   }
 }


### PR DESCRIPTION
- Use SIA v0.5.3 with v0.2.13 and v0.2.17 (aggregation improvements and kmux panic fixes)
- Adds hardening engine (minimum version would be v0.1.27)
- Adds new releases