### PR TITLE
feat(accessKeys): add ability to onboard vm using accessKeys

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/docker/docker v24.0.7+incompatible
 	github.com/gdamore/tcell/v2 v2.6.0
+	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/jedib0t/go-pretty v4.3.0+incompatible
 	github.com/kubearmor/kubearmor-client v0.14.2

--- a/go.sum
+++ b/go.sum
@@ -1239,6 +1239,8 @@ github.com/gogo/protobuf v1.3.0/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXP
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
+github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=

--- a/pkg/onboard/types.go
+++ b/pkg/onboard/types.go
@@ -1,5 +1,7 @@
 package onboard
 
+import "errors"
+
 type ClusterType string
 type VMMode string
 
@@ -221,3 +223,19 @@ type KmuxConfigTemplateArgs struct {
 	ServerURL      string
 	RMQServer      string
 }
+
+type TokenResponse struct {
+	// if success join_token and message will be populated
+	JoinToken string `json:"join_token"`
+	Message   string `json:"message"`
+
+	// if failure error_code and error_message will be populated
+	ErrorCode    string `json:"error_code"`
+	ErrorMessage string `json:"error_message"`
+}
+
+var (
+	ErrInvalidToken = errors.New("invalid JWT format")
+)
+
+const AccessKeyEndpoint = "/access-token/api/v1/process"


### PR DESCRIPTION
**Fixes:** [CNAPP-13260](https://accu-knox.atlassian.net/browse/CNAPP-13260)

This PR adds the ability for a user to onboard a VM without going to the Onboard page in the SaaS UI.

**Required fields:**
- **Access Key:** Generated from the User Management page in the SaaS UI
- **VM Name:** Name of the VM to be shown on the SaaS UI
- **Access Key URL:** CWPP endpoint for getting join_token from the access key

**Sample `knoxctl` command:**

```
knoxctl onboard vm cp-node \
  --version v0.6.3 \
  --spire-host=spire.dev.accuknox.com \
  --pps-host=pps.dev.accuknox.com \
  --knox-gateway=knox-gw.dev.accuknox.com:3000 \
  --vm-name="<vm-name-to-be-shown-in-ui" \
  --access-key-url="cwpp.<env>.accuknox.com" \
  --access-key="<access-key-generated-from-saas-ui>"
```

[CNAPP-13260]: https://accu-knox.atlassian.net/browse/CNAPP-13260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ