### PR TITLE
fix(discoverySD): add rules visibility to discover

### DIFF
--- a/pkg/onboard/cpNodeSD.go
+++ b/pkg/onboard/cpNodeSD.go
@@ -23,6 +23,8 @@ func (ic *InitConfig) InitializeControlPlaneSD() error {
 	ic.TCArgs.HardenAddr = "0.0.0.0:32771"
 	ic.TCArgs.VmMode = ic.Mode
 
+	ic.TCArgs.DiscoverRules = combineVisibilities(ic.Visibility, ic.HostVisibility)
+
 	err := SystemdInstall(ic.ClusterConfig)
 	if err != nil {
 		fmt.Println(cm.Red + "Installation failed!! Cleaning up downloaded assets:" + cm.Reset)


### PR DESCRIPTION
### **Issue:** The discovery module installed in `systemd` mode was unable to generate policies. 
The discovery module requires the following configuration:
```
ruleConfig:
    rules: <rules>
```

This configuration was missing in systemd mode, leading to the aforementioned issue.
