### PR TITLE
chore: update release flow and add patch version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,7 +62,7 @@ jobs:
           body: "Release ${{ steps.get_tag.outputs.TAG_NAME }} for knoxctl a.k.a accuknox-cli."
           repository: accuknox/knoxctl-website
           token: ${{ secrets.AK_PAT_REPO_SCOPE }}
-          make_latest: true
+          make_latest: false
           files: |
             dist/*.tar.gz
             dist/*.txt


### PR DESCRIPTION
- Make it possible to install latest patch release of any minor release by specifying the `major.minor` release tag. Example:
![image](https://github.com/user-attachments/assets/8d0d66a7-6dea-452d-b462-dfe0f9f16f3a)
