### PR TITLE
fix(configs): update policy and summary topic

### DIFF
--- a/pkg/onboard/templates/discover-config.yaml
+++ b/pkg/onboard/templates/discover-config.yaml
@@ -5,7 +5,7 @@ discover:
       network: 100
       system: 1000
     time-limit: 1
-    topic: summary-v2
+    topic: {{.SummaryV2Topic}}
   policy-client:
     server: 127.0.0.1:8090
   processor:
@@ -18,7 +18,7 @@ discover:
     rules: {{.DiscoverRules}}
   sink:
     channel-size: 100
-    topic: policy-v1
+    topic: {{.PolicyV1Topic}}
   k8s:
     enable: false
   tls:

--- a/pkg/onboard/templates/hardening-agent-config.yaml
+++ b/pkg/onboard/templates/hardening-agent-config.yaml
@@ -4,7 +4,7 @@ hardening:
   enabled: true
   recommend-host-policy: true
   template-version: "0.2.6"
-  topic: "policy-v1"
+  topic: {{.PolicyV1Topic}}
   delay-cron-job: "0h05m00s"
   filter-enabled: false
   exclude-namespaces:

--- a/pkg/onboard/templates/sumengine-config.yaml
+++ b/pkg/onboard/templates/sumengine-config.yaml
@@ -25,7 +25,7 @@ summary-engine:
   threshold: 10000
   file-aggregation: true
   topic:
-    summary-event: "summary-v2"
+    summary-event: {{.SummaryV2Topic}}
   exclude-events:
     operation:
       process: {{.ProcessOperation}}


### PR DESCRIPTION
This change is required if we have multiple control plane nodes running in k8s. To differentiate the summary and policy from each nodes we will add the topic-prefix so that the topic will become something like `<topic-prefix>-summary-v2` and `<topic-prefix>-policy-v1` 