### PR TITLE
fix(rmq): add queue name and consumer tag

### DIFF
--- a/pkg/onboard/cpNode.go
+++ b/pkg/onboard/cpNode.go
@@ -242,6 +242,8 @@ func (ic *InitConfig) InitializeControlPlane() error {
 
 		// generate kmux config only if it exists for this agent
 		if agentObj.kmuxConfigPath != "" {
+			kmuxConfigArgs.ConsumerTag = agentObj.agentName
+			kmuxConfigArgs.QueueName = fmt.Sprintf("%s-%s", ic.TCArgs.RMQTopicPrefix, agentObj.agentName)
 			if _, err := copyOrGenerateFile(ic.UserConfigPath, agentConfigPath, agentObj.kmuxConfigFileName, sprigFuncs, agentObj.kmuxConfigTemplateString, kmuxConfigArgs); err != nil {
 				return err
 			}

--- a/pkg/onboard/cpNodeSD.go
+++ b/pkg/onboard/cpNodeSD.go
@@ -93,6 +93,8 @@ func (ic *InitConfig) InitializeControlPlaneSD() error {
 
 		// copy kmux config
 		if obj.KmuxConfigPath != "" {
+			kmuxConfigArgs.ConsumerTag = obj.AgentName
+			kmuxConfigArgs.QueueName = fmt.Sprintf("%s-%s", ic.TCArgs.RMQTopicPrefix, obj.AgentName)
 			_, err = copyOrGenerateFile(ic.UserConfigPath, obj.AgentDir, cm.KmuxConfigFileName, ic.TemplateFuncs, obj.KmuxConfigTemplateString, kmuxConfigArgs)
 			if err != nil {
 				return err

--- a/pkg/onboard/node.go
+++ b/pkg/onboard/node.go
@@ -205,6 +205,8 @@ func (jc *JoinConfig) JoinWorkerNode() error {
 	}
 	// Generate or copy kmux config files
 	for filePath, templateString := range kmuxConfigFileTemplateMap {
+		kmuxConfigArgs.QueueName = fmt.Sprintf("%s-%s", jc.RMQTopicPrefix, strings.Split(filePath, "/")[0])
+		kmuxConfigArgs.ConsumerTag = strings.Split(filePath, "/")[0]
 		if _, err := copyOrGenerateFile(jc.UserConfigPath, configPath, filePath, sprigFuncs, templateString, kmuxConfigArgs); err != nil {
 			return err
 		}

--- a/pkg/onboard/systemdNode.go
+++ b/pkg/onboard/systemdNode.go
@@ -78,6 +78,8 @@ func (jc *JoinConfig) JoinSystemdNode() error {
 
 		// copy kmux config
 		if obj.KmuxConfigPath != "" {
+			kmuxConfigArgs.QueueName = fmt.Sprintf("%s-%s", jc.RMQTopicPrefix, strings.TrimPrefix(obj.AgentName, "accuknox-"))
+			kmuxConfigArgs.ConsumerTag = strings.TrimPrefix(obj.AgentName, "accuknox-")
 			// copy generic config files
 			_, err = copyOrGenerateFile(jc.UserConfigPath, obj.AgentDir, cm.KmuxConfigFileName, jc.TemplateFuncs, obj.KmuxConfigTemplateString, kmuxConfigArgs)
 			if err != nil {

--- a/pkg/onboard/templates/discover-kmux-config.yaml
+++ b/pkg/onboard/templates/discover-kmux-config.yaml
@@ -15,7 +15,8 @@ rabbitmq:
   queue:
     auto-delete: true
     durable: true
-    name: ""
+    name: {{.QueueName}}
+  consumer-tag: {{.ConsumerTag}}
   server: {{.RMQServer}}
   tls: 
     enabled: {{.TlsEnabled}}

--- a/pkg/onboard/templates/hardening-agent-kmux-config.yaml
+++ b/pkg/onboard/templates/hardening-agent-kmux-config.yaml
@@ -14,9 +14,10 @@ rabbitmq:
     durable: true
     auto-delete: true
   queue:
-    name: ""
+    name: {{.QueueName}}
     durable: true
     auto-delete: true
+  consumer-tag: {{.ConsumerTag}}
   tls: 
     enabled: {{.TlsEnabled}}
     cert-file: "/opt/cert/encoded.pem"

--- a/pkg/onboard/templates/kmux-config.yaml
+++ b/pkg/onboard/templates/kmux-config.yaml
@@ -26,9 +26,10 @@ rabbitmq:
     durable: true
     auto-delete: true
   queue:
-    name: ""
+    name: {{.QueueName}}
     durable: true
     auto-delete: true
+  consumer-tag: {{.ConsumerTag}}
   debug: false
   tls: 
     enabled: {{.TlsEnabled}}

--- a/pkg/onboard/templates/pea-rmq-kmux-config.yaml
+++ b/pkg/onboard/templates/pea-rmq-kmux-config.yaml
@@ -23,9 +23,10 @@ rabbitmq:
     durable: true
     auto-delete: true
   queue:
-    name: ""
+    name: {{.QueueName}}
     durable: true
     auto-delete: true
+  consumer-tag: {{.ConsumerTag}}
   debug: false
   tls: 
     enabled: {{.TlsEnabled}}

--- a/pkg/onboard/templates/sumengine-kmux-config.yaml
+++ b/pkg/onboard/templates/sumengine-kmux-config.yaml
@@ -16,7 +16,8 @@ rabbitmq:
   queue:
     auto-delete: true
     durable: true
-    name: ""
+    name: {{.QueueName}}
+  consumer-tag: {{.ConsumerTag}}
   debug: false
   tls: 
     enabled: {{.TlsEnabled}}

--- a/pkg/onboard/types.go
+++ b/pkg/onboard/types.go
@@ -273,6 +273,8 @@ type KmuxConfigTemplateArgs struct {
 	RMQPassword    string
 	TlsEnabled     bool
 	TlsCertFile    string
+	ConsumerTag    string
+	QueueName      string
 }
 
 type TokenResponse struct {


### PR DESCRIPTION
This PR adds queue name and consumer tag to kmux config for rabbimq connections 

Sample onboarding command:

```
knoxctl onboard vm cp-node \
  --version v0.7.1 \
  --join-token="" \
  --spire-host=spire.dev.accuknox.com \
  --pps-host=pps.dev.accuknox.com \
  --knox-gateway=knox-gw.dev.accuknox.com:3000 \
  --tls --cp-name="tenant1" --dry-run
```

Discovery module sample kmux file
```
kmux:
  sink:
    stream: rabbitmq
rabbitmq:
  username: ""
  password: ""
  exchange:
    auto-delete: true
    durable: true
    name: agents
    type: direct
  queue:
    auto-delete: true
    durable: true
    name: tenant1-discover
  consumer-tag: discover
  server: rabbitmq:5672
  tls: 
    enabled: true
    cert-file: ""
    skip-verify: false

```