### PR TITLE
fix(sumengine): enable rabbitmq only when tls and cp-node

### DIFF
--- a/pkg/onboard/templates/sumengine-config.yaml
+++ b/pkg/onboard/templates/sumengine-config.yaml
@@ -14,10 +14,12 @@ watcher:
     url: {{.RelayServerAddr}}
     port: {{.RelayServerPort}}
 {{- end }}
+{{- if and .TlsEnabled (not .WorkerNode) }}
   rabbitmq:
     enabled: true
     logs-topic: {{.LogsTopic}}
     alerts-topic: {{.AlertsTopic}}
+{{- end }}
 
 summary-engine:
   enabled: true


### PR DESCRIPTION
**Fixes:** [CNAPP-15542](https://accu-knox.atlassian.net/browse/CNAPP-15542)

This PR contains the following changes:

- Enable rabbitmq config in summary-engine only when deployed on cp-node and tls is enabled 

[CNAPP-15542]: https://accu-knox.atlassian.net/browse/CNAPP-15542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ