### PR TITLE
fix: warning orphan containers while installing RAT

### DIFF
--- a/pkg/onboard/templates/docker-compose_rat.yaml
+++ b/pkg/onboard/templates/docker-compose_rat.yaml
@@ -1,3 +1,4 @@
+name: accuknox-rat
 services:
   rat:
     profiles:


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/1e3424ad-ab7b-49f3-ad07-e55a96891b9b)

fixed 

![image](https://github.com/user-attachments/assets/552d84ff-ddcf-48ec-b141-374dceb67c22)
