### PR TITLE
ci: build `rra` binary before knoxctl

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,6 +40,10 @@ jobs:
         run: |
           git config --global url."https://${USER}:${TOKEN}@github.com".insteadOf "https://github.com"
 
+      - name: Build rra binary
+        run: make
+        shell: bash
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:


### PR DESCRIPTION
`rra` binary is embedded by knoxctl at build time using Go's embed fs. This change ensures that the `rra` binary is built before `knoxctl`.