### PR TITLE
fix(compatibility): add backward compatibility for agents

### DIFF
--- a/pkg/common/release.json
+++ b/pkg/common/release.json
@@ -1371,7 +1371,7 @@
     "sia_tag": "v0.7.3",
     "sia_image": "accuknox/shared-informer-agent",
     "pea_tag": "v0.6.4",
-    "pea_image": "accuknox/polcy-enforcement-agent",
+    "pea_image": "accuknox/policy-enforcement-agent",
     "feeder_service_tag": "v0.8.0",
     "feeder_service_image": "accuknox/feeder-service",
     "discover_tag": "v0.2.6",
@@ -1404,7 +1404,7 @@
     "rat_tag": "v0.4.1",
     "rat_image": "accuknox/rat"
   },
-  "v0.9.2   ": {
+  "v0.9.2": {
     "creation_time": "1736508314",
     "kubearmor_tag": "v1.5.2",
     "kubearmor_relay_tag": "v0.0.4",
@@ -1469,7 +1469,7 @@
   },
   "v0.9.5": {
     "creation_time": "1742909967",
-    "kubearmor_tag": "v1.5.5",
+    "kubearmor_tag": "v1.5.6",
     "kubearmor_relay_tag": "v0.0.4",
     "kubearmor_vm_adapter_tag": "v0.1.10",
     "spire_agent_tag": "v1.9.4",
@@ -1480,11 +1480,11 @@
     "feeder_service_tag": "v0.8.3",
     "feeder_service_image": "accuknox/feeder-service",
     "discover_tag": "v0.3.1",
-    "discover_image": "accuknox/discovery-engine-discover",
+    "discover_image": "public.ecr.aws/k9v9d5v2/discovery-engine-discover",
     "sumengine_tag": "v0.3.1",
-    "sumengine_image": "accuknox/discovery-engine-sumengine",
+    "sumengine_image": "public.ecr.aws/k9v9d5v2/discovery-engine-sumengine",
     "hardening_agent_tag": "v0.3.1",
-    "hardening_agent_image": "accuknox/discovery-engine-hardening",
+    "hardening_agent_image": "public.ecr.aws/k9v9d5v2/discovery-engine-hardening",
     "rat_tag": "v0.4.1",
     "rat_image": "accuknox/rat"
   }

--- a/pkg/onboard/cpNodeSD.go
+++ b/pkg/onboard/cpNodeSD.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Masterminds/sprig"
 	cm "github.com/accuknox/accuknox-cli-v2/pkg/common"
 	"github.com/accuknox/accuknox-cli-v2/pkg/logger"
+	"golang.org/x/mod/semver"
 )
 
 func (ic *InitConfig) InitializeControlPlaneSD() error {
@@ -143,6 +144,9 @@ func (ic *InitConfig) InitializeControlPlaneSD() error {
 	logger.Info2("\nEnabling services...")
 	for _, obj := range ic.SystemdServiceObjects {
 		if obj.AgentName == cm.SummaryEngine && !ic.DeploySumengine {
+			continue
+		}
+		if obj.AgentName == cm.HardeningAgent && semver.Compare(ic.TCArgs.ReleaseVersion, "v0.9.4") >= 0 {
 			continue
 		}
 		err = StartSystemdService(obj.ServiceName)

--- a/pkg/onboard/systemdNode.go
+++ b/pkg/onboard/systemdNode.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Masterminds/sprig"
 	cm "github.com/accuknox/accuknox-cli-v2/pkg/common"
 	"github.com/accuknox/accuknox-cli-v2/pkg/logger"
+	"golang.org/x/mod/semver"
 )
 
 func (jc *JoinConfig) JoinSystemdNode() error {
@@ -126,6 +127,9 @@ func (jc *JoinConfig) JoinSystemdNode() error {
 			continue
 		}
 		if obj.AgentName == cm.SummaryEngine && !jc.DeploySumengine {
+			continue
+		}
+		if obj.AgentName == cm.HardeningAgent && semver.Compare(jc.TCArgs.ReleaseVersion, "v0.9.4") >= 0 {
 			continue
 		}
 		err = StartSystemdService(obj.ServiceName)

--- a/pkg/onboard/systemdUtils.go
+++ b/pkg/onboard/systemdUtils.go
@@ -15,10 +15,10 @@ import (
 	"strings"
 
 	"github.com/Masterminds/sprig"
-	"github.com/accuknox/accuknox-cli-v2/pkg/common"
 	cm "github.com/accuknox/accuknox-cli-v2/pkg/common"
 	"github.com/accuknox/accuknox-cli-v2/pkg/logger"
 	"github.com/coreos/go-systemd/v22/dbus"
+	"golang.org/x/mod/semver"
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content/file"
 	"oras.land/oras-go/v2/registry/remote"
@@ -335,6 +335,9 @@ func (cc *ClusterConfig) placeServiceFiles() error {
 		if obj.AgentName == cm.SummaryEngine && !cc.DeploySumengine {
 			continue
 		}
+		if obj.AgentName == cm.HardeningAgent && semver.Compare(cc.AgentsVersion, "v0.9.4") >= 0 {
+			continue
+		}
 		if obj.ServiceTemplateString != "" {
 
 			if obj.AgentName == cm.RAT {
@@ -517,6 +520,10 @@ func (cc *ClusterConfig) SystemdInstall() error {
 			continue
 		}
 
+		if obj.AgentName == cm.HardeningAgent && semver.Compare(cc.AgentsVersion, "v0.9.4") >= 0 {
+			continue
+		}
+
 		logger.Print("Downloading Agent - %s | Image - %s", obj.AgentName, obj.AgentImage)
 		packageMeta := splitLast(obj.AgentImage, ":")
 
@@ -657,7 +664,7 @@ func DeboardSystemd(nodeType NodeType) error {
 		Deletedir(cm.LogrotateDir + obj.PackageName)
 	}
 
-	knoxctlDir := filepath.Clean(filepath.Join(common.SystemdKnoxctlDir, common.KnoxctlConfigFilename))
+	knoxctlDir := filepath.Clean(filepath.Join(cm.SystemdKnoxctlDir, cm.KnoxctlConfigFilename))
 	err := os.Remove(knoxctlDir)
 	if err != nil {
 		logger.Warn("Failed to remove dir %s: %s", knoxctlDir, err.Error())
@@ -854,7 +861,7 @@ func DumpSystemdAgentInstallation(sysdumpDir string) {
 		}
 
 		if service.ServiceName != "" {
-			systemdServicePath := filepath.Join(common.SystemdDir, service.ServiceName)
+			systemdServicePath := filepath.Join(cm.SystemdDir, service.ServiceName)
 			sysdumpServicePath := filepath.Join(sysdumpDir, service.ServiceName)
 			if err := readAndDumpFile(systemdServicePath, sysdumpServicePath); err != nil && !os.IsNotExist(err) {
 				logger.Warn("Failed to copy files form %s to %s: %s", systemdServicePath, sysdumpServicePath, err.Error())

--- a/pkg/onboard/templates/docker-compose_cp-node.yaml
+++ b/pkg/onboard/templates/docker-compose_cp-node.yaml
@@ -173,7 +173,9 @@ services:
     pull_policy: "{{.ImagePullPolicy}}"
     command:
       - "--kubearmor-addr={{.KubeArmorURL}}"
+      {{- if trimPrefix "v" .ReleaseVersion | semverCompare ">0.9.1" }}
       - "--node-state-refresh={{.NodeStateRefreshTime}}"
+      {{- end }}
       {{- if .TlsEnabled }}
       - "--tls"
       - "--policy-topic={{.PoliciesTopic}}"
@@ -242,7 +244,7 @@ services:
         condition: service_started
       discover:
         condition: service_started
-      {{- if not .TlsEnabled }}
+      {{- if and (not .TlsEnabled) (semverCompare "<0.9.4" (trimPrefix "v" .ReleaseVersion)) }}
       hardening-agent:
         condition: service_started
       {{- end }}
@@ -370,6 +372,7 @@ services:
       accuknox-net:
         aliases:
           - sumengine
+  {{- if trimPrefix "v" .ReleaseVersion | semverCompare "<0.9.4" }}
   hardening-agent:
     profiles:
       - "accuknox-agents"
@@ -396,7 +399,7 @@ services:
       accuknox-net:
         aliases:
           - hardening-agent
-
+  {{- end }}
   {{- if .DeployRMQ }}
   rabbitmq:
     image: {{.RMQImage}}

--- a/pkg/onboard/templates/docker-compose_node.yaml
+++ b/pkg/onboard/templates/docker-compose_node.yaml
@@ -89,7 +89,9 @@ services:
     command:
       - "--kubearmor-addr={{.KubeArmorURL}}"
       - "--relay-server-addr={{.RelayServerURL}}"
+      {{- if trimPrefix "v" .ReleaseVersion | semverCompare ">0.9.1" }}
       - "--node-state-refresh={{.NodeStateRefreshTime}}"
+      {{- end }}
       {{- if .TlsEnabled }}
       - "--tls"
       - "--policy-topic={{.PoliciesTopic}}"

--- a/pkg/onboard/templates/hardening-agent-config.yaml
+++ b/pkg/onboard/templates/hardening-agent-config.yaml
@@ -1,7 +1,7 @@
 hardening:
   cron-job-time-interval: "1h00m00s"
   download-templates: false
-  enabled: false
+  enabled: true
   recommend-host-policy: true
   template-version: "0.2.6"
   topic: {{.PolicyV1Topic}}

--- a/pkg/onboard/templates/systemdTemplates/vm-adapter-config.yaml
+++ b/pkg/onboard/templates/systemdTemplates/vm-adapter-config.yaml
@@ -2,7 +2,9 @@ kubearmor-addr: {{.KubeArmorURL}}
 
 relay-server-addr: {{.RelayServerURL}}
 
+{{- if trimPrefix "v" .ReleaseVersion | semverCompare ">0.9.1" }}
 node-state-refresh: {{.NodeStateRefreshTime}}
+{{- end }}
 
 {{- if .TlsEnabled }}
 tls: {{.TlsEnabled}}


### PR DESCRIPTION
**Fixes:** [CNAPP-19395](https://accu-knox.atlassian.net/browse/CNAPP-19395)

This PR contains the following changes:
- Make node-state-refresh available only for charts version > v0.9.1
- Disable hardening module permanently for chart version > v0.9.4
- Remove trailing space in v0.9.2 key in release.json
- Update image repository for release v0.9.0 and v0.9.5 

[CNAPP-19395]: https://accu-knox.atlassian.net/browse/CNAPP-19395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ