### PR TITLE
fix(semver): add release version to systemd installation

### DIFF
--- a/pkg/onboard/systemdNode.go
+++ b/pkg/onboard/systemdNode.go
@@ -54,6 +54,8 @@ func (jc *JoinConfig) JoinSystemdNode() error {
 		}
 	}
 
+	jc.TCArgs.ReleaseVersion = jc.AgentsVersion
+
 	// config services
 	kmuxConfigArgs := KmuxConfigTemplateArgs{
 		ReleaseVersion: jc.AgentsVersion,

--- a/pkg/onboard/systemdUtils.go
+++ b/pkg/onboard/systemdUtils.go
@@ -327,6 +327,7 @@ func (cc *ClusterConfig) placeServiceFiles() error {
 	configArgs := map[string]interface{}{
 		"WorkerNode":       cc.WorkerNode,
 		"UseSystemdAppend": useSystemdAppend(),
+		"ReleaseVersion":   cc.AgentsVersion,
 	}
 	for _, obj := range cc.SystemdServiceObjects {
 		if cc.WorkerNode && !obj.InstallOnWorkerNode {


### PR DESCRIPTION
Fixes the following error in vm-node onboarding

![image](https://github.com/user-attachments/assets/ee5a512b-3a85-4acb-8f15-bd014c06c3a8)
