### PR TITLE
fix(version): only get latest version if flag is enabled

### DIFF
--- a/pkg/onboard/cpNodeSD.go
+++ b/pkg/onboard/cpNodeSD.go
@@ -87,10 +87,7 @@ func (ic *InitConfig) InitializeControlPlaneSD() error {
 
 	logger.Info2("\nConfiguring services...")
 	for _, obj := range ic.SystemdServiceObjects {
-		// copy generic config files
-		if obj.AgentName == cm.SummaryEngine && !ic.DeploySumengine {
-			continue
-		}
+
 		if obj.ConfigFilePath != "" {
 			// copy template args
 			tcArgs := ic.TCArgs

--- a/pkg/onboard/version.go
+++ b/pkg/onboard/version.go
@@ -114,7 +114,7 @@ func DetermineKAVersionLegacy() (string, error) {
 		return "", err
 	}
 
-	version := "unkown"
+	version := "unknown"
 	for _, obj := range legacyVersionObjects {
 		if obj.MD5 == string(md5SumString) {
 			version = obj.Version

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -31,12 +31,12 @@ type Option struct {
 // PrintVersion displays the current version and checks for updates
 func PrintVersion(c *k8s.Client, o Option) error {
 	fmt.Printf("knoxctl's version: %s (Built on %s)\n", GitSummary, BuildDate)
-	releaseVer, err := fetchReleaseVersion()
-	if err != nil {
-		return fmt.Errorf("error fetching latest version: %v", err)
-	}
 
 	if o.LatestRelease {
+		releaseVer, err := fetchReleaseVersion()
+		if err != nil {
+			return fmt.Errorf("error fetching latest version: %v", err)
+		}
 		fmt.Printf("knoxctl release version: [%v]\n", releaseVer)
 	}
 


### PR DESCRIPTION

**Fixes:** [CNAPP-19721](https://accu-knox.atlassian.net/browse/CNAPP-19721)

**This PR contains the following changes:**
- Only get latest release from the website if `--latest-release` flag is set in the version command
- changed `unkown` to ` unknown`


**Related PR:** https://github.com/accuknox/pkgversions/pull/1

[CNAPP-19721]: https://accu-knox.atlassian.net/browse/CNAPP-19721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ