### PR TITLE
remove PAT requirement for knoxctl selfupdate

### DIFF
--- a/cmd/selfupdate.go
+++ b/cmd/selfupdate.go
@@ -25,6 +25,5 @@ var selfUpdateCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(selfUpdateCmd)
-	selfUpdateCmd.Flags().StringVar(&options.GitPATPath, "git-pat", "", "Path to your personal access token")
 	selfUpdateCmd.Flags().BoolVarP(&options.DoUpdate, "yes", "y", false, "Force update to latest version")
 }

--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,6 @@ require (
 	github.com/spf13/viper v1.18.2
 	golang.org/x/mod v0.17.0
 	golang.org/x/net v0.29.0
-	golang.org/x/oauth2 v0.21.0
 	golang.org/x/sync v0.8.0
 	golang.org/x/term v0.24.0
 	google.golang.org/grpc v1.66.2
@@ -354,6 +353,7 @@ require (
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/crypto v0.27.0 // indirect
 	golang.org/x/exp v0.0.0-20240110193028-0dcbfd608b1e // indirect
+	golang.org/x/oauth2 v0.21.0 // indirect
 	golang.org/x/sys v0.25.0 // indirect
 	golang.org/x/text v0.18.0 // indirect
 	golang.org/x/time v0.5.0 // indirect

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -49,8 +49,9 @@ const (
 	OffloaderConfMap = "dev2-offloader"
 	SumEngineConfMap = "dev2-sumengine"
 
-	AccuknoxGithub  = "accuknox"
-	AccuknoxCLIRepo = "accuknox-cli-v2"
+	AccuknoxGithub         = "accuknox"
+	AccuknoxCLIRepo        = "accuknox-cli-v2"
+	AccuknoxKnoxctlwebsite = "knoxctl-website"
 
 	DefaultConfigPathDirName = ".accuknox-config"
 

--- a/pkg/common/github.go
+++ b/pkg/common/github.go
@@ -4,34 +4,21 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"os"
 
 	"github.com/google/go-github/github"
-	"golang.org/x/oauth2"
 )
 
 // SetupGitHubClient sets up a GitHub client with the provided PAT, it uses oAuth2 to authenticate
-func SetupGitHubClient(pat string, ctx context.Context) (*github.Client, error) {
-	if pat == "" {
-		return nil, os.ErrInvalid
-	}
+func SetupGitHubClient(ctx context.Context) (*github.Client, error) {
 
-	if err := checkGithubHealth(); err != nil {
-		return nil, err
-	}
-
-	ts := oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: pat},
-	)
-	tc := oauth2.NewClient(ctx, ts)
-	client := github.NewClient(tc)
+	client := github.NewClient(nil)
 
 	return client, nil
 }
 
 // GetLatestRelease returns the latest release from the GitHub API
 func GetLatestRelease(client *github.Client, ctx context.Context) (*github.RepositoryRelease, error) {
-	latestRelease, _, err := client.Repositories.GetLatestRelease(ctx, AccuknoxGithub, AccuknoxCLIRepo)
+	latestRelease, _, err := client.Repositories.GetLatestRelease(ctx, AccuknoxGithub, AccuknoxKnoxctlwebsite)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -79,22 +79,18 @@ func getKubeArmorVersion(c *k8s.Client) (string, error) {
 	return "", nil
 }
 
-func ShouldUpdate(currentVersion, pat string) (bool, error) {
-	if pat == "" {
-		return false, fmt.Errorf("GitHub Personal Access Token (PAT) is required")
-	}
+func ShouldUpdate(currentVersion string) (bool, string, string, error) {
 
-	client, err := common.SetupGitHubClient(pat, context.Background())
+	client, err := common.SetupGitHubClient(context.Background())
 	if err != nil {
-		return false, fmt.Errorf("error setting up GitHub client: %v", err)
+		return false, "", currentVersion, fmt.Errorf("error setting up GitHub client: %v", err)
 	}
 
 	latestVersion, err := common.GetLatestVersion(client, context.Background())
 	if err != nil {
-		return false, fmt.Errorf("error checking latest version: %v", err)
+		return false, "", currentVersion, fmt.Errorf("error checking latest version: %v", err)
 	}
-
-	return latestVersion != currentVersion, nil
+	return latestVersion != currentVersion, latestVersion, currentVersion, nil
 }
 
 func fetchReleaseVersion() (string, error) {


### PR DESCRIPTION
Currently, we use [accuknox/accuknox-cli-v2](https://github.com/accuknox/accuknox-cli-v2) (a private repository) to download the latest releases, which requires a GitHub Personal Access Token (PAT) for authentication.

This PR updates the source to [accuknox/knoxctl-website](https://github.com/accuknox/knoxctl-website/releases), which is a public repository, thereby removing the need for a PAT during the update process.