### PR TITLE
fix(imagescan): Add prerequisite check for trivy

### DIFF
--- a/cmd/imagescan.go
+++ b/cmd/imagescan.go
@@ -19,6 +19,9 @@ var imageScanCmd = &cobra.Command{
 and sends back the result to saas through artifact API
 		`,
 	Args: cobra.NoArgs,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		return imagescan.IsTrivyInstalled()
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return imagescan.DiscoverAndScan(cfg, HOST_NAME, RUN_TIME)
 	},

--- a/pkg/imagescan/imagescan.go
+++ b/pkg/imagescan/imagescan.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"syscall"
 
 	kubesheildDiscovery "github.com/accuknox/kubeshield/pkg/discovery"
@@ -91,4 +92,11 @@ func discoverImages(logger *zap.SugaredLogger, hostName, runtime string) []kubes
 		}
 	}
 	return images
+}
+
+func IsTrivyInstalled() error {
+	if _, err := exec.LookPath("trivy"); err != nil {
+		return fmt.Errorf("Trivy is not installed or not found in $PATH. Please install Trivy to enable image scanning")
+	}
+	return nil
 }


### PR DESCRIPTION
**Purpose of this PR?**

- Add prerequisite check for trivy for `image-scan` command.

**Ticket:** https://accu-knox.atlassian.net/browse/CNAPP-20546
