### PR TITLE
feat(imagescan): Install trivy if its not exists

### DIFF
--- a/cmd/imagescan.go
+++ b/cmd/imagescan.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/accuknox/accuknox-cli-v2/pkg/imagescan"
 	kubesheildConfig "github.com/accuknox/kubeshield/pkg/scanner/config"
 	"github.com/spf13/cobra"
@@ -20,6 +22,10 @@ and sends back the result to saas
 		`,
 	Args: cobra.NoArgs,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
+		if !imagescan.IsValidDomain(cfg.ScanConfig.ArtifactAPI) {
+			return fmt.Errorf("invalid domain name: %s", cfg.ScanConfig.ArtifactAPI)
+		}
+		cfg.ScanConfig.ArtifactAPI = fmt.Sprintf("https://%s/api/v1/artifact/", cfg.ScanConfig.ArtifactAPI)
 		return imagescan.IsTrivyInstalled()
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/imagescan.go
+++ b/cmd/imagescan.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/accuknox/accuknox-cli-v2/pkg/imagescan"
 	kubesheildConfig "github.com/accuknox/kubeshield/pkg/scanner/config"
@@ -9,9 +10,11 @@ import (
 )
 
 var (
-	HOST_NAME string
-	RUN_TIME  string
-	cfg       = kubesheildConfig.Config{}
+	HOST_NAME                   string
+	RUN_TIME                    string
+	artifactEndpointPath        string
+	cfg                         = kubesheildConfig.Config{}
+	defaultArtifactEndpointPath = "/api/v1/artifact/"
 )
 
 var imageScanCmd = &cobra.Command{
@@ -21,14 +24,32 @@ var imageScanCmd = &cobra.Command{
 and sends back the result to saas
 		`,
 	Args: cobra.NoArgs,
-	PreRunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if strings.HasPrefix(cfg.ScanConfig.ArtifactAPI, "http://") {
+			return fmt.Errorf("http scheme not supported: %s", cfg.ScanConfig.ArtifactAPI)
+		}
+
+		// Adds Scheme if not present
+		if !strings.HasPrefix(cfg.ScanConfig.ArtifactAPI, "https://") {
+			cfg.ScanConfig.ArtifactAPI = "https://" + cfg.ScanConfig.ArtifactAPI
+		}
+
+		// Checks whether the domain is in vaild regex pattern
 		if !imagescan.IsValidDomain(cfg.ScanConfig.ArtifactAPI) {
 			return fmt.Errorf("invalid domain name: %s", cfg.ScanConfig.ArtifactAPI)
 		}
-		cfg.ScanConfig.ArtifactAPI = fmt.Sprintf("https://%s/api/v1/artifact/", cfg.ScanConfig.ArtifactAPI)
-		return imagescan.IsTrivyInstalled()
-	},
-	RunE: func(cmd *cobra.Command, args []string) error {
+
+		// if artifact endpoint(after domain) is empty then use default value
+		if artifactEndpointPath == "" {
+			artifactEndpointPath = defaultArtifactEndpointPath
+		}
+
+		if !strings.HasPrefix(artifactEndpointPath, "/") {
+			artifactEndpointPath = "/" + artifactEndpointPath
+		}
+
+		cfg.ScanConfig.ArtifactAPI += artifactEndpointPath
 		return imagescan.DiscoverAndScan(cfg, HOST_NAME, RUN_TIME)
 	},
 }
@@ -37,13 +58,14 @@ func init() {
 
 	// Artifact API Configurations
 	imageScanCmd.Flags().StringVarP(&cfg.ScanConfig.ArtifactAPI, "artifactEndpoint", "", "",
-		"scanned results will sent back to saas through this api")
+		"Specify the domain name of the artifact endpoint")
+	imageScanCmd.Flags().StringVarP(&artifactEndpointPath, "artifactEndpointPath", "", "",
+		"Optional: specify the URL path segment after the domain name")
 	imageScanCmd.Flags().StringVarP(&cfg.ScanConfig.Label, "label", "l", "", "used to filter the finding based on the label")
 	imageScanCmd.Flags().StringVarP(&cfg.ScanConfig.ArtifactToken, "token", "t", "", "token required for authentication")
 	imageScanCmd.Flags().StringVarP(&cfg.ScanConfig.TenantID, "tenantId", "", "", "tenant id")
 
 	// Scan Configurations
-	// imageScanCmd.Flags().StringVarP(&cfg.ScanConfig.ScanTool, "tool", "", "trivy", "container image scanning tool")
 	imageScanCmd.Flags().StringVarP(&HOST_NAME, "hostname", "", "", "name of the host")
 	imageScanCmd.Flags().StringVarP(&RUN_TIME, "runtime", "r", "", "container runtime used in the host machine")
 

--- a/cmd/imagescan.go
+++ b/cmd/imagescan.go
@@ -15,8 +15,8 @@ var (
 var imageScanCmd = &cobra.Command{
 	Use:   "image-scan",
 	Short: "scans vm container images",
-	Long: `Scans VM container images using trivy 
-and sends back the result to saas through artifact API
+	Long: `Scans VM container images 
+and sends back the result to saas
 		`,
 	Args: cobra.NoArgs,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -37,7 +37,7 @@ func init() {
 	imageScanCmd.Flags().StringVarP(&cfg.ScanConfig.TenantID, "tenantId", "", "", "tenant id")
 
 	// Scan Configurations
-	imageScanCmd.Flags().StringVarP(&cfg.ScanConfig.ScanTool, "tool", "", "trivy", "tool used for scanning")
+	// imageScanCmd.Flags().StringVarP(&cfg.ScanConfig.ScanTool, "tool", "", "trivy", "container image scanning tool")
 	imageScanCmd.Flags().StringVarP(&HOST_NAME, "hostname", "", "", "name of the host")
 	imageScanCmd.Flags().StringVarP(&RUN_TIME, "runtime", "r", "", "container runtime used in the host machine")
 

--- a/pkg/imagescan/imagescan.go
+++ b/pkg/imagescan/imagescan.go
@@ -50,6 +50,7 @@ func DiscoverAndScan(conf kubesheildConfig.Config, hostName, runtime string) err
 
 	// Additional fields added along with the scan results while calling artifact API
 	conf.ScanConfig.AdditionalData = map[string]any{"host_name": hostName}
+	conf.ScanConfig.ScanTool = "trivy" // Default scanning tool
 
 	imageScanner := kubesheildScanner.New(conf)
 

--- a/pkg/imagescan/imagescan.go
+++ b/pkg/imagescan/imagescan.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"regexp"
 	"syscall"
 
 	kubesheildDiscovery "github.com/accuknox/kubeshield/pkg/discovery"
@@ -100,4 +101,11 @@ func IsTrivyInstalled() error {
 		return fmt.Errorf("Trivy is not installed or not found in $PATH. Please install Trivy to enable image scanning")
 	}
 	return nil
+}
+
+func IsValidDomain(domain string) bool {
+	// Basic regex for domain name validation (simplified)
+	// This does not cover all edge cases or internationalized domain names (IDNs)
+	re := regexp.MustCompile(`^[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$`)
+	return re.MatchString(domain)
 }

--- a/pkg/imagescan/installBinary.go
+++ b/pkg/imagescan/installBinary.go
@@ -1,0 +1,128 @@
+package imagescan
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+)
+
+var defaultInstallationPath = filepath.Join(os.Getenv("HOME"), ".accuknox-config", "container-scanner")
+
+// Download and install the provided binary
+func DownloadAndInstallBinary(url, targetDir string) error {
+
+	// Download the tar.gz file
+	tarReader, err := downloadTarGz(url)
+	if err != nil {
+		return err
+	}
+
+	defer tarReader.Close()
+
+	// Decompress and untar the downloaded tar.gz file
+	result, err := untar(tarReader, targetDir)
+	if err != nil {
+		return err
+	}
+
+	// copy the executable to the provided path
+	return installBinary(result, targetDir)
+}
+
+// Creates the file in the provided path and sets the file permission to executable.
+func installBinary(binary io.Reader, binaryPath string) error {
+	outFile, err := os.Create(path.Clean(binaryPath))
+	if err != nil {
+		return err
+	}
+
+	defer outFile.Close()
+
+	if _, err := io.Copy(outFile, binary); err != nil {
+		return err
+	}
+
+	// Make it executable
+	err = os.Chmod(binaryPath, 0700) // #nosec G302
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Download the tar.gz file
+func downloadTarGz(rawURL string) (io.ReadCloser, error) {
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.Get(parsedURL.String())
+	if err != nil {
+		return nil, fmt.Errorf("failed to download file: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		if err := resp.Body.Close(); err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("unexpected HTTP status: %s", resp.Status)
+	}
+
+	return resp.Body, nil
+}
+
+// Decompress the tar.gz file
+func untar(src io.Reader, binaryPath string) (io.Reader, error) {
+
+	gz, err := gzip.NewReader(src)
+	if err != nil {
+		return nil, err
+	}
+	return unarchiveTar(gz, binaryPath)
+}
+
+// Untar the tar archive for the provided binary
+func unarchiveTar(gzStream io.Reader, binaryPath string) (io.Reader, error) {
+	tarReader := tar.NewReader(gzStream)
+	_, binaryName := filepath.Split(binaryPath)
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		// Return only the untar of the provided binary
+		if header.Typeflag == tar.TypeReg && filepath.Base(header.Name) == binaryName {
+			return tarReader, nil
+		}
+	}
+	return nil, fmt.Errorf("%s binary not found in tar.gz", binaryName)
+}
+
+// Creating the binary path, if not exists
+func getBinaryPath() (string, error) {
+	if err := os.MkdirAll(defaultInstallationPath, 0750); err != nil {
+		return "", err
+	}
+
+	// Including the newly created path to the $PATH variable
+	newPath := fmt.Sprintf("%s:%s", defaultInstallationPath, os.Getenv("PATH"))
+	if err := os.Setenv("PATH", newPath); err != nil {
+		return "", err
+	}
+	return defaultInstallationPath, nil
+}
+
+// Delete Installed binary
+func cleanupInstalledBinaryPath() error {
+	return os.RemoveAll(defaultInstallationPath)
+}

--- a/pkg/imagescan/trivy.go
+++ b/pkg/imagescan/trivy.go
@@ -1,0 +1,84 @@
+package imagescan
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+)
+
+var defaultTrivyVersion = "0.64.1"
+
+// Returns the tar.gz url for the provided trivy version
+func GetTrivyDownloadURL(version string) string {
+	osName := mapOS(runtime.GOOS)
+	archName := mapArch(runtime.GOARCH)
+
+	if osName == "" || archName == "" {
+		fmt.Printf("unsupported platform: %s-%s\n", runtime.GOOS, runtime.GOARCH)
+	}
+
+	// Construct the URL
+	return fmt.Sprintf(
+		"https://github.com/aquasecurity/trivy/releases/download/v%s/trivy_%s_%s-%s.tar.gz",
+		version, version, osName, archName,
+	)
+}
+
+func mapOS(goos string) string {
+	switch strings.ToLower(goos) {
+	case "linux":
+		return "Linux"
+	case "darwin":
+		return "macOS"
+	case "windows":
+		return "Windows"
+	default:
+		return ""
+	}
+}
+
+func mapArch(goarch string) string {
+	switch goarch {
+	case "amd64":
+		return "64bit"
+	case "386":
+		return "32bit"
+	case "arm64":
+		return "ARM64"
+	case "arm":
+		return "ARM"
+	default:
+		return ""
+	}
+}
+
+// Checks if trivy is present in the $PATH variable
+func IsTrivyInstalled() bool {
+	if _, err := exec.LookPath("trivy"); err != nil {
+		fmt.Println("Container image scanner is not installed or not found in $PATH. Installing It...")
+		return false
+	}
+	return true
+}
+
+func IsValidDomain(domain string) bool {
+	// regex for domain name validation
+	re := regexp.MustCompile(`^https:\/\/[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$`)
+	return re.MatchString(domain)
+}
+
+// Installs trivy at $HOME/.accuknox-config/container-scanner
+func installTrivy() error {
+	binaryPath, err := getBinaryPath()
+	if err != nil {
+		return fmt.Errorf("error while creating binary path: %v", err)
+	}
+	if err := DownloadAndInstallBinary(GetTrivyDownloadURL(defaultTrivyVersion),
+		filepath.Join(binaryPath, "trivy")); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
**Purpose of this PR?**

- Remove Trivy as the default tool from the CLI flags.
- Modify the --artifactEndpoint flag to accept only the domain name instead of the full URL.
- Automatically install Trivy if it is not already present, and clean up the binary after the scan is completed. 

**Tickets:**
- https://accu-knox.atlassian.net/browse/CNAPP-20815
- https://accu-knox.atlassian.net/browse/CNAPP-20820
- https://accu-knox.atlassian.net/browse/CNAPP-20816