### PR TITLE
Ignore GoReleaser to build for Darwin based systems

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,7 +3,7 @@ project_name: knoxctl
 builds:
   - binary: knoxctl
     goos:
-      - darwin
+      # - darwin
       - linux
     goarch:
       - amd64


### PR DESCRIPTION
Currently skipping package build for Sarwin based machines as the same is causing issue in building go packages 
Since go package does not support syscalls which is specific to Unix ...