### PR TITLE
feat(onboard): add pre-onboard inspection and rmq connectivity

### DIFF
--- a/cmd/onboard-vm-cp-node.go
+++ b/cmd/onboard-vm-cp-node.go
@@ -10,6 +10,7 @@ import (
 	"github.com/accuknox/accuknox-cli-v2/pkg/common"
 	"github.com/accuknox/accuknox-cli-v2/pkg/logger"
 	"github.com/accuknox/accuknox-cli-v2/pkg/onboard"
+	"github.com/accuknox/accuknox-cli-v2/pkg/vm"
 	"github.com/spf13/cobra"
 )
 
@@ -60,6 +61,16 @@ var cpNodeCmd = &cobra.Command{
 	Use:   "cp-node",
 	Short: "Initialize a control plane node for onboarding onto SaaS",
 	Long:  "Initialize a control plane node for onboarding onto SaaS",
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		inspectionOptions := options
+		inspectionOptions.Print = printInspectOutput
+
+		if err := vm.InspectVM(&inspectionOptions); err != nil {
+			return err
+		}
+
+		return nil
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// validate environment for pre-requisites
 		var (

--- a/cmd/onboard-vm-node.go
+++ b/cmd/onboard-vm-node.go
@@ -10,6 +10,7 @@ import (
 	"github.com/accuknox/accuknox-cli-v2/pkg/common"
 	"github.com/accuknox/accuknox-cli-v2/pkg/logger"
 	"github.com/accuknox/accuknox-cli-v2/pkg/onboard"
+	"github.com/accuknox/accuknox-cli-v2/pkg/vm"
 	"github.com/spf13/cobra"
 )
 
@@ -32,6 +33,16 @@ var joinNodeCmd = &cobra.Command{
 	Use:   "node",
 	Short: "Join this worker node with the control plane node for onboarding onto SaaS",
 	Long:  "Join this worker node with the control plane node for onboarding onto SaaS",
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		inspectionOptions := options
+		inspectionOptions.Print = printInspectOutput
+
+		if err := vm.InspectVM(&inspectionOptions); err != nil {
+			return err
+		}
+
+		return nil
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 

--- a/cmd/onboard-vm.go
+++ b/cmd/onboard-vm.go
@@ -204,7 +204,7 @@ func init() {
 
 	onboardVMCmd.PersistentFlags().StringVar(&releaseFile, "release-file", "", "release file containing release versions of accuknox agents")
 
-	onboardVMCmd.PersistentFlags().BoolVar(&printInspectOutput, "print-inspect", true, "print output of inspect command")
+	onboardVMCmd.PersistentFlags().BoolVar(&printInspectOutput, "print-inspect", false, "print output of inspect command")
 
 	onboardCmd.AddCommand(onboardVMCmd)
 }

--- a/cmd/onboard-vm.go
+++ b/cmd/onboard-vm.go
@@ -76,6 +76,8 @@ var (
 	parallel int
 
 	releaseFile string
+
+	printInspectOutput bool
 )
 
 // onboardVMCmd represents the sub-command to onboard VM clusters
@@ -88,7 +90,6 @@ var onboardVMCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-
 		return nil
 	},
 }
@@ -202,6 +203,8 @@ func init() {
 	onboardVMCmd.PersistentFlags().StringVar(&knoxGateway, "knox-gateway", "", "address of knox-gateway to connect with for pushing telemetry data")
 
 	onboardVMCmd.PersistentFlags().StringVar(&releaseFile, "release-file", "", "release file containing release versions of accuknox agents")
+
+	onboardVMCmd.PersistentFlags().BoolVar(&printInspectOutput, "print-inspect", true, "print output of inspect command")
 
 	onboardCmd.AddCommand(onboardVMCmd)
 }

--- a/cmd/vm-inspect.go
+++ b/cmd/vm-inspect.go
@@ -36,5 +36,7 @@ func init() {
 	vmCmd.PersistentFlags().StringVar(&options.PPSURL, "pps-url", "https://pps.accuknox.com:443", "address of control plane")                        // pps url
 	vmCmd.PersistentFlags().StringVar(&options.KnoxGwURL, "knox-gw-url", "http://knox-gw.accuknox.com:3000", "address of control plane")             // knox-gw-url
 
+	vmCmd.PersistentFlags().BoolVar(&options.Print, "print-output", true, "print output")
+
 	vmCmd.AddCommand(vmInspectCmd)
 }

--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/mholt/archiver/v3 v3.5.1
 	github.com/nothinux/certify v1.8.0
 	github.com/olekukonko/tablewriter v0.0.5
+	github.com/rabbitmq/amqp091-go v1.10.0
 	github.com/rivo/tview v0.0.0-20231115183240-7c9e464bac02
 	github.com/rs/zerolog v1.34.0
 	github.com/samber/lo v1.51.0
@@ -288,7 +289,6 @@ require (
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.64.0 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
-	github.com/rabbitmq/amqp091-go v1.10.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/robfig/cron v1.2.0 // indirect
 	github.com/rs/xid v1.6.0 // indirect

--- a/pkg/onboard/node.go
+++ b/pkg/onboard/node.go
@@ -215,13 +215,11 @@ func (jc *JoinConfig) JoinWorkerNode() error {
 	jc.TCArgs.SumEngineImage = jc.SumEngineImage
 	jc.TCArgs.TlsEnabled = jc.Tls.Enabled
 
-	if jc.Tls.RMQCredentials != "" {
-		rmqData := strings.Split(Decode(jc.Tls.RMQCredentials), ":")
-		if len(rmqData) != 2 {
-			return fmt.Errorf("invalid RMQ credentials")
-		}
-		jc.TCArgs.RMQUsername = rmqData[0]
-		jc.TCArgs.RMQPassword = rmqData[1]
+	jc.TCArgs.RMQUsername,
+		jc.TCArgs.RMQPassword,
+		err = getRMQUserPass(jc.Tls.RMQCredentials)
+	if err != nil {
+		return err
 	}
 
 	// initialize sprig for templating

--- a/pkg/onboard/systemdNode.go
+++ b/pkg/onboard/systemdNode.go
@@ -1,9 +1,7 @@
 package onboard
 
 import (
-	"fmt"
 	"path/filepath"
-	"strings"
 
 	"github.com/Masterminds/sprig"
 	cm "github.com/accuknox/accuknox-cli-v2/pkg/common"
@@ -31,14 +29,11 @@ func (jc *JoinConfig) JoinSystemdNode() error {
 
 	jc.TCArgs.AccessKey = jc.AccessKey
 
-	if jc.Tls.RMQCredentials != "" {
-
-		rmqData := strings.Split(Decode(jc.Tls.RMQCredentials), ":")
-		if len(rmqData) != 2 {
-			return fmt.Errorf("invalid RMQ credentials")
-		}
-		jc.TCArgs.RMQUsername = rmqData[0]
-		jc.TCArgs.RMQPassword = rmqData[1]
+	jc.TCArgs.RMQUsername,
+		jc.TCArgs.RMQPassword,
+		err = getRMQUserPass(jc.Tls.RMQCredentials)
+	if err != nil {
+		return err
 	}
 
 	if jc.Tls.Enabled {

--- a/pkg/onboard/utils.go
+++ b/pkg/onboard/utils.go
@@ -2,6 +2,8 @@ package onboard
 
 import (
 	"bytes"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -19,6 +21,7 @@ import (
 	se_splunk "github.com/accuknox/dev2/sumengine/pkg/sumengine/kubearmor"
 	"github.com/docker/docker/client"
 	"github.com/golang-jwt/jwt"
+	amqp "github.com/rabbitmq/amqp091-go"
 	"golang.org/x/mod/semver"
 )
 
@@ -548,4 +551,65 @@ func validateSplunkCredential(splunkConfig SplunkConfig) error {
 
 func getLastOldVersion(agentName string) string {
 	return cm.LastOldAgentVersion[agentName]
+}
+
+func getRMQUserPass(credentials string) (string, string, error) {
+
+	if credentials == "" {
+		return "", "", nil
+	}
+
+	rmqUserPass := strings.Split(Decode(credentials), ":")
+	if len(rmqUserPass) != 2 {
+		return "", "", fmt.Errorf("invalid RMQ credentials")
+	}
+	return rmqUserPass[0], rmqUserPass[1], nil
+}
+
+func testRMQConnection(rmqAddress, rmqUsername, rmqPassword, caCert, caPath string) error {
+	if rmqUsername == "" {
+		rmqUsername = "guest"
+	}
+	if rmqPassword == "" {
+		rmqPassword = "guest"
+	}
+
+	connectionString := fmt.Sprintf("amqp://%s:%s@%s", rmqUsername, rmqPassword, rmqAddress)
+	if caCert != "" || caPath != "" {
+		connectionString = strings.Replace(connectionString, "amqp://", "amqps://", 1)
+	}
+
+	config := amqp.Config{
+		Properties: amqp.Table{
+			"connection_name": "test_connection",
+		},
+	}
+
+	if caCert != "" || caPath != "" {
+
+		if caPath != "" {
+			ca, err := os.ReadFile(caPath)
+			if err != nil {
+				return err
+			}
+			caCert = string(ca)
+		}
+
+		decoded := Decode(caCert)
+		caCertPool := x509.NewCertPool()
+		if ok := caCertPool.AppendCertsFromPEM([]byte(decoded)); !ok {
+			return fmt.Errorf("failed to add server CA certificates to client pool")
+		}
+		config.TLSClientConfig = &tls.Config{
+			RootCAs: caCertPool,
+		}
+	}
+
+	conn, err := amqp.DialConfig(connectionString, config)
+	if err != nil {
+		return fmt.Errorf("\nfailed to connect to RabbitMQ at %s: %w. \nPlease verify flags --rmq-address, --auth, and --ca-path", rmqAddress, err)
+	}
+	defer conn.Close()
+
+	return nil
 }

--- a/pkg/onboard/utils.go
+++ b/pkg/onboard/utils.go
@@ -588,7 +588,7 @@ func testRMQConnection(rmqAddress, rmqUsername, rmqPassword, caCert, caPath stri
 	if caCert != "" || caPath != "" {
 
 		if caPath != "" {
-			ca, err := os.ReadFile(caPath)
+			ca, err := os.ReadFile(filepath.Clean(caPath))
 			if err != nil {
 				return err
 			}
@@ -601,7 +601,8 @@ func testRMQConnection(rmqAddress, rmqUsername, rmqPassword, caCert, caPath stri
 			return fmt.Errorf("failed to add server CA certificates to client pool")
 		}
 		config.TLSClientConfig = &tls.Config{
-			RootCAs: caCertPool,
+			RootCAs:    caCertPool,
+			MinVersion: tls.VersionTLS12,
 		}
 	}
 

--- a/pkg/vm/vm-inspect.go
+++ b/pkg/vm/vm-inspect.go
@@ -13,6 +13,7 @@ type Options struct {
 	PPSURL          string
 	KnoxGwURL       string
 	CPNodeAddr      string
+	Print           bool
 }
 
 func InspectVM(o *Options) error {
@@ -58,23 +59,23 @@ func InspectVM(o *Options) error {
 		kaCompatible.VmMode = vmMode
 	}
 
-	printNodeData(*kaCompatible)
-	printData(portsAvailability, "PORTS", "STATUS", "Ports Availability")
+	printNodeData(*kaCompatible, o.Print)
+	printData(portsAvailability, "PORTS", "STATUS", "Ports Availability", o.Print)
 	if len(installedAgents) > 0 {
-		printData(installedAgents, "AGENTS", "STATUS", "Accuknox Agents")
+		printData(installedAgents, "AGENTS", "STATUS", "Accuknox Agents", o.Print)
 	} else {
 		// if there are no agents installed , check connectivity.
 		if o.CPNodeAddr == "" {
 			// treat it as control plane node
 			output := checkSAASconnectivity(o)
-			printData(output, "URL", "STATUS", "Accuknox Connectivity")
+			printData(output, "URL", "STATUS", "Accuknox Connectivity", o.Print)
 		} else {
-			// it's a worker-node and check connectivity to contol plane node'
-			output, err := checkNodeconnectivity(o)
+			// it's a worker-node and check connectivity to control plane node'
+			output, err := checkNodeConnectivity(o)
 			if err != nil {
-				logger.Error("Error checking controlplane connectivity", err.Error())
+				logger.Error("Error checking control-plane connectivity", err.Error())
 			}
-			printData(output, "Node Address", "STATUS", "Control Plane Connectivity")
+			printData(output, "Node Address", "STATUS", "Control Plane Connectivity", o.Print)
 		}
 	}
 


### PR DESCRIPTION
**JIRA:** [CNAPP-22249](https://accu-knox.atlassian.net/browse/CNAPP-22249)

This PR contains the following changes:
- runs the vm-inspect command internally to check connectivity to SaaS and open ports
  - new flag `--print-inspect=false` to disable printing of vm-inspect output (default value is true)
- adds additional check in systemd cp-node for rabbitmq connectivity   

<img width="3128" height="1722" alt="print_true_image" src="https://github.com/user-attachments/assets/2088d1e4-9342-41e6-a029-d3c4a9288799" />

<img width="3128" height="1722" alt="print_false_image" src="https://github.com/user-attachments/assets/6e41c2c9-9cb5-42c6-99d4-1e0bd663c69d" />


[CNAPP-22249]: https://accu-knox.atlassian.net/browse/CNAPP-22249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ