### PR TITLE
chore(imagescan): Remove Tenant-ID flag from image-scan command

### DIFF
--- a/cmd/imagescan.go
+++ b/cmd/imagescan.go
@@ -65,7 +65,6 @@ func init() {
 		"Optional: specify the URL path segment after the domain name")
 	imageScanCmd.Flags().StringVarP(&cfg.ArtifactConfig.Label, "label", "l", "", "used to filter the finding based on the label")
 	imageScanCmd.Flags().StringVarP(&cfg.ArtifactConfig.ArtifactToken, "token", "t", "", "token required for authentication")
-	imageScanCmd.Flags().StringVarP(&cfg.ArtifactConfig.TenantID, "tenantId", "", "", "tenant id")
 
 	// Scan Configurations
 	imageScanCmd.Flags().StringVarP(&HOST_NAME, "hostname", "", "", "name of the host")
@@ -74,7 +73,7 @@ func init() {
 	imageScanCmd.Flags().BoolVar(&imagesOnly, "images-only", false, "If set, discovers and scans all images. By default, only images from running containers are scanned.")
 
 	// Required Flags Validation
-	imageScanCmd.MarkFlagsOneRequired("artifactEndpoint", "token", "label", "tenantId")
-	imageScanCmd.MarkFlagsRequiredTogether("artifactEndpoint", "token", "label", "tenantId")
+	imageScanCmd.MarkFlagsOneRequired("artifactEndpoint", "token", "label")
+	imageScanCmd.MarkFlagsRequiredTogether("artifactEndpoint", "token", "label")
 	rootCmd.AddCommand(imageScanCmd)
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/accuknox/accuknox-cli-v2
 go 1.24.4
 
 replace (
-	github.com/accuknox/kubeshield v0.1.2-0.20250922132133-ee9e8a145dbc => github.com/accuknox/kubesheild v0.1.2-0.20250922132133-ee9e8a145dbc
+	github.com/accuknox/kubeshield v0.1.2-0.20251111150757-1b3db72011d9 => github.com/accuknox/kubesheild v0.1.2-0.20251111150757-1b3db72011d9
 	github.com/etcd-io/bbolt => go.etcd.io/bbolt v1.3.6
 	github.com/google/gnostic-models v0.7.0 => github.com/google/gnostic-models v0.6.9
 	github.com/optiopay/kafka => github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b
@@ -26,7 +26,7 @@ require (
 	github.com/accuknox/dev2/discover v0.0.0-20231026051927-56fe5412ae0d
 	github.com/accuknox/dev2/hardening v0.0.0-20250720150630-0e643f247e04
 	github.com/accuknox/dev2/sumengine v0.0.0-20250109055732-04767b7ac965
-	github.com/accuknox/kubeshield v0.1.2-0.20250922132133-ee9e8a145dbc
+	github.com/accuknox/kubeshield v0.1.2-0.20251111150757-1b3db72011d9
 	github.com/clarketm/json v1.17.1
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/creativeprojects/go-selfupdate v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -658,8 +658,8 @@ github.com/accuknox/kmux v0.0.0-20250508061720-e1de0cfcf3c0 h1:E8+8bNeDJZPuyiiUN
 github.com/accuknox/kmux v0.0.0-20250508061720-e1de0cfcf3c0/go.mod h1:EHl+JGuicZ6jxpJReHChXIf/xO30VlpY6rr4taSxdIM=
 github.com/accuknox/knox-gateway v0.9.2 h1:NNYNTMXJvic1i3elWEz00bv+sIuAtWyxfH1L8oTSVS4=
 github.com/accuknox/knox-gateway v0.9.2/go.mod h1:+pkmjrI1u1q886houOBv5+SRSl+VVhxtj76RvbXG0Bo=
-github.com/accuknox/kubesheild v0.1.2-0.20250922132133-ee9e8a145dbc h1:aCZ0iVX1DgBmu0FgXJCHJgw/ErAIMGTTb49cLuH7TOk=
-github.com/accuknox/kubesheild v0.1.2-0.20250922132133-ee9e8a145dbc/go.mod h1:JG/NyLeiy8SMyWwSDwGNeM70d9S9lurS31zmQhtGCqg=
+github.com/accuknox/kubesheild v0.1.2-0.20251111150757-1b3db72011d9 h1:Umt+pzL8vXObYBVGx2say2w3jL9Tab45hrcsXv0u3eA=
+github.com/accuknox/kubesheild v0.1.2-0.20251111150757-1b3db72011d9/go.mod h1:fTLN87QQVqVkCLJKXuB2ws4A16+w+CWZQhi1vuj/RBQ=
 github.com/accuknox/registry-scanning/common v0.0.0-20250513065108-b8f4ebc6e184 h1:SosoWCeLygJJF+0rRM6hepu1TjjAdAx7hKPS4u7PtvA=
 github.com/accuknox/registry-scanning/common v0.0.0-20250513065108-b8f4ebc6e184/go.mod h1:5d4T8cT58DJfaid5PE5N7+7qZ5/LBeFTAAjB2DBIGwM=
 github.com/ajstarks/deck v0.0.0-20200831202436-30c9fc6549a9/go.mod h1:JynElWSGnm/4RlzPXRlREEwqTHAN3T56Bv2ITsFT3gY=

--- a/pkg/imagescan/imagescan.go
+++ b/pkg/imagescan/imagescan.go
@@ -62,7 +62,8 @@ func DiscoverAndScan(conf kubesheildScanner.ScanConfig, hostName, runtime string
 	conf.ArtifactConfig.AdditionalData = map[string]any{"host_name": hostName}
 	conf.ScanTool = "trivy" // Default scanning tool
 
-	imageScanner := kubesheildScanner.New(conf)
+	// Passing nil kubernetes.Clientset, because it won't be required incase of VM container Image scanning
+	imageScanner := kubesheildScanner.New(conf, nil)
 	imageScanner.ScannerHttpClient = httpclient.New()
 
 	// Scans the provided images and sends the result back to saas through the artifact API


### PR DESCRIPTION
**Purpose of this PR?**

- TenantID is not required to be passed as a query parameter while calling the artifact API, because tenantID will be taken from the artifact token itself. 