### PR TITLE
feat(resource): limit resource for kubearmor and agents

### DIFF
--- a/cmd/onboard-vm-cp-node.go
+++ b/cmd/onboard-vm-cp-node.go
@@ -139,6 +139,9 @@ var cpNodeCmd = &cobra.Command{
 			return err
 		}
 
+		vmConfig.KaResource = kaResource
+		vmConfig.AgentsResource = agentsResource
+
 		if accessKey != "" {
 			if joinToken, err = vmConfig.PopulateAccessKeyConfig(tokenURL, accessKey, topicPrefix, vmName, tokenEndpoint, "vm", insecure); err != nil {
 				return err
@@ -153,7 +156,6 @@ var cpNodeCmd = &cobra.Command{
 				logger.Warn("Failed to create config dump at %s: %s", configDumpPath, err.Error())
 			}
 		}()
-
 		err = onboardConfig.CreateBaseTemplateConfig()
 		if err != nil {
 			logger.Error("failed to create base template config: %s", err.Error())

--- a/cmd/onboard-vm-node.go
+++ b/cmd/onboard-vm-node.go
@@ -118,6 +118,8 @@ var joinNodeCmd = &cobra.Command{
 			logger.Error("failed to create VM config: %s", err.Error())
 			return err
 		}
+		vmConfigs.KaResource = kaResource
+		vmConfigs.AgentsResource = agentsResource
 
 		if accessKey != "" {
 			if joinToken, err = vmConfigs.PopulateAccessKeyConfig(tokenURL, accessKey, topicPrefix, vmName, tokenEndpoint, "Node", insecure); err != nil {

--- a/cmd/onboard-vm.go
+++ b/cmd/onboard-vm.go
@@ -78,6 +78,8 @@ var (
 	releaseFile string
 
 	printInspectOutput bool
+	kaResource         onboard.ResourceConfig
+	agentsResource     onboard.ResourceConfig
 )
 
 // onboardVMCmd represents the sub-command to onboard VM clusters
@@ -205,6 +207,15 @@ func init() {
 	onboardVMCmd.PersistentFlags().StringVar(&releaseFile, "release-file", "", "release file containing release versions of accuknox agents")
 
 	onboardVMCmd.PersistentFlags().BoolVar(&printInspectOutput, "print-inspect", false, "print output of inspect command")
+
+	// resource config for agents and kubearmor
+	onboardVMCmd.PersistentFlags().Int64Var(&kaResource.CPUQuota, "kubearmor.cpu-quota", 5, "cpu quota for kubearmor in percentage. eg: 5")
+	onboardVMCmd.PersistentFlags().Int64Var(&kaResource.MemoryMax, "kubearmor.memory-max", 300, "memory max for kubearmor in MB. eg: 300")
+	onboardVMCmd.PersistentFlags().Int64Var(&kaResource.MemoryHigh, "kubearmor.memory-high", 240, "memory quota for kubearmor in MB. eg: 240")
+
+	onboardVMCmd.PersistentFlags().Int64Var(&agentsResource.CPUQuota, "agents.cpu-quota", 5, "cpu quota for agents in percentage. eg: 5")
+	onboardVMCmd.PersistentFlags().Int64Var(&agentsResource.MemoryMax, "agents.memory-max", 100, "memory max for agents in MB. eg: 100")
+	onboardVMCmd.PersistentFlags().Int64Var(&agentsResource.MemoryHigh, "agents.memory-high", 80, "memory quota for agents in MB. eg: 80")
 
 	onboardCmd.AddCommand(onboardVMCmd)
 }

--- a/pkg/onboard/cpNodeSD.go
+++ b/pkg/onboard/cpNodeSD.go
@@ -178,24 +178,23 @@ func (ic *InitConfig) InitializeControlPlaneSD() error {
 	return nil
 }
 
-func useSystemdAppend() bool {
-
+func getSystemdVersion() int {
 	cmd := exec.Command("systemctl", "--version")
 	out, err := cmd.Output()
 	if err != nil {
-		return false
+		return 240
 	}
 	lines := strings.Split(string(out), "\n")
 	if len(lines) == 0 {
-		return false
+		return 240
 	}
 	fields := strings.Fields(lines[0])
 	if len(fields) < 2 {
-		return false
+		return 240
 	}
 	version, err := strconv.Atoi(fields[1])
 	if err != nil {
-		return false
+		return 240
 	}
-	return version > 240
+	return version
 }

--- a/pkg/onboard/systemdUtils.go
+++ b/pkg/onboard/systemdUtils.go
@@ -332,9 +332,9 @@ func getSystemdAgentsKmuxConfigs(cc *ClusterConfig) []SystemdServiceObject {
 // placeServiceFiles copies service files
 func (cc *ClusterConfig) placeServiceFiles() error {
 	configArgs := map[string]any{
-		"WorkerNode":       cc.WorkerNode,
-		"UseSystemdAppend": useSystemdAppend(),
-		"ReleaseVersion":   cc.AgentsVersion,
+		"WorkerNode":     cc.WorkerNode,
+		"SystemdVersion": getSystemdVersion(),
+		"ReleaseVersion": cc.AgentsVersion,
 	}
 
 	if cc.AdditionalArgs != nil {
@@ -350,6 +350,16 @@ func (cc *ClusterConfig) placeServiceFiles() error {
 		}
 		if obj.AgentName == cm.HardeningAgent && semver.Compare(cc.AgentsVersion, "v0.9.4") >= 0 {
 			continue
+		}
+
+		configArgs["CPUQuota"] = fmt.Sprintf("%v%s", cc.AgentsResource.CPUQuota, "%")
+		configArgs["MemoryMax"] = fmt.Sprintf("%vM", cc.AgentsResource.MemoryMax)
+		configArgs["MemoryHigh"] = fmt.Sprintf("%vM", cc.AgentsResource.MemoryHigh)
+
+		if obj.AgentName == cm.KubeArmor {
+			configArgs["CPUQuota"] = fmt.Sprintf("%v%s", cc.KaResource.CPUQuota, "%")
+			configArgs["MemoryMax"] = fmt.Sprintf("%vM", cc.KaResource.MemoryMax)
+			configArgs["MemoryHigh"] = fmt.Sprintf("%vM", cc.KaResource.MemoryHigh)
 		}
 
 		if obj.ServiceTemplateString != "" {

--- a/pkg/onboard/templates/systemdTemplates/discover.service
+++ b/pkg/onboard/templates/systemdTemplates/discover.service
@@ -7,7 +7,7 @@ User=root
 KillMode=control-group
 WorkingDirectory=/opt/accuknox-discover/
 ExecStart=/opt/accuknox-discover/discover --config conf/config.yaml --kmux-config kmux-config.yaml
-{{- if .UseSystemdAppend }}
+{{- if gt .SystemdVersion 240 }}
 StandardOutput=append:/opt/accuknox-discover/accuknox-discover.log
 StandardError=append:/opt/accuknox-discover/accuknox-discover-err.log
 {{- else }}
@@ -16,6 +16,19 @@ StandardError=file:/opt/accuknox-discover/accuknox-discover-err.log
 {{- end }}
 Restart=always
 RestartSec=10
+
+CPUQuota={{ .CPUQuota | default "5%" }}
+MemoryMax={{ .MemoryMax | default "100M" }}
+
+{{- if gt .SystemdVersion 241 }}
+MemoryHigh={{ .MemoryHigh | default "80M" }}
+{{- end }}
+
+{{- if gt .SystemdVersion 241 }}
+CPUWeight=50
+{{- end }}
+
+OOMPolicy=kill
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/onboard/templates/systemdTemplates/feeder-service.service
+++ b/pkg/onboard/templates/systemdTemplates/feeder-service.service
@@ -7,7 +7,7 @@ User=root
 KillMode=control-group
 WorkingDirectory=/opt/accuknox-feeder-service/
 EnvironmentFile=/opt/accuknox-feeder-service/conf/env
-{{- if .UseSystemdAppend }}
+{{- if gt .SystemdVersion 240 }}
 StandardOutput=append:/opt/accuknox-feeder-service/accuknox-feeder-service.log
 StandardError=append:/opt/accuknox-feeder-service/accuknox-feeder-service-err.log
 {{- else }}
@@ -17,6 +17,19 @@ StandardError=file:/opt/accuknox-feeder-service/accuknox-feeder-service-err.log
 ExecStart=/opt/accuknox-feeder-service/accuknox-feeder-service
 Restart=always
 RestartSec=10
+
+CPUQuota={{ .CPUQuota | default "5%" }}
+MemoryMax={{ .MemoryMax | default "100M" }}
+
+{{- if gt .SystemdVersion 241 }}
+MemoryHigh={{ .MemoryHigh | default "80M" }}
+{{- end }}
+
+{{- if gt .SystemdVersion 241 }}
+CPUWeight=50
+{{- end }}
+
+OOMPolicy=kill
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/onboard/templates/systemdTemplates/hardening-agent.service
+++ b/pkg/onboard/templates/systemdTemplates/hardening-agent.service
@@ -7,7 +7,7 @@ User=root
 KillMode=control-group
 WorkingDirectory=/opt/accuknox-hardening-agent/
 ExecStart=/opt/accuknox-hardening-agent/hardening start --config conf/config.yaml --kmux-config kmux-config.yaml --templates /opt/accuknox-hardening-agent/resources/policy_templates.zip
-{{- if .UseSystemdAppend }}
+{{- if gt .SystemdVersion 240 }}
 StandardOutput=append:/opt/accuknox-hardening-agent/accuknox-hardening-agent.log
 StandardError=append:/opt/accuknox-hardening-agent/accuknox-hardening-agent-err.log
 {{- else }}
@@ -16,6 +16,19 @@ StandardError=file:/opt/accuknox-hardening-agent/accuknox-hardening-agent-err.lo
 {{- end }}
 Restart=always
 RestartSec=10
+
+CPUQuota={{ .CPUQuota | default "5%" }}
+MemoryMax={{ .MemoryMax | default "100M" }}
+
+{{- if gt .SystemdVersion 241 }}
+MemoryHigh={{ .MemoryHigh | default "80M" }}
+{{- end }}
+
+{{- if gt .SystemdVersion 241 }}
+CPUWeight=50
+{{- end }}
+
+OOMPolicy=kill
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/onboard/templates/systemdTemplates/kubearmor.service
+++ b/pkg/onboard/templates/systemdTemplates/kubearmor.service
@@ -6,7 +6,7 @@ User=root
 KillMode=control-group
 WorkingDirectory=/opt/kubearmor/
 ExecStart=/opt/kubearmor/kubearmor
-{{- if .UseSystemdAppend }}
+{{- if gt .SystemdVersion 240 }}
 StandardOutput=append:/opt/kubearmor/kubearmor.log
 StandardError=append:/opt/kubearmor/kubearmor-err.log
 {{- else }}
@@ -15,6 +15,19 @@ StandardError=file:/opt/kubearmor/kubearmor-err.log
 {{- end }}
 Restart=always
 RestartSec=10
+
+CPUQuota={{ .CPUQuota | default "5%" }}
+MemoryMax={{ .MemoryMax | default "300M" }}
+
+{{- if gt .SystemdVersion 241 }}
+MemoryHigh={{ .MemoryHigh | default "250M" }}
+{{- end }}
+
+{{- if gt .SystemdVersion 241 }}
+CPUWeight=50
+{{- end }}
+
+OOMPolicy=kill
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/onboard/templates/systemdTemplates/pea.service
+++ b/pkg/onboard/templates/systemdTemplates/pea.service
@@ -7,7 +7,7 @@ User=root
 KillMode=control-group
 WorkingDirectory=/opt/accuknox-policy-enforcement-agent/
 ExecStart=/opt/accuknox-policy-enforcement-agent/accuknox-policy-enforcement-agent
-{{- if .UseSystemdAppend }}
+{{- if gt .SystemdVersion 240 }}
 StandardOutput=append:/opt/accuknox-policy-enforcement-agent/accuknox-policy-enforcement-agent.log
 StandardError=append:/opt/accuknox-policy-enforcement-agent/accuknox-policy-enforcement-agent-err.log
 {{- else }}
@@ -16,5 +16,20 @@ StandardError=file:/opt/accuknox-policy-enforcement-agent/accuknox-policy-enforc
 {{- end }}
 Restart=always
 RestartSec=10
+
+
+CPUQuota={{ .CPUQuota | default "5%" }}
+MemoryMax={{ .MemoryMax | default "100M" }}
+
+{{- if gt .SystemdVersion 241 }}
+MemoryHigh={{ .MemoryHigh | default "80M" }}
+{{- end }}
+
+{{- if gt .SystemdVersion 241 }}
+CPUWeight=50
+{{- end }}
+
+OOMPolicy=kill
+
 [Install]
 WantedBy=multi-user.target

--- a/pkg/onboard/templates/systemdTemplates/relay-server.service
+++ b/pkg/onboard/templates/systemdTemplates/relay-server.service
@@ -7,7 +7,7 @@ User=root
 KillMode=control-group
 WorkingDirectory=/opt/kubearmor-relay-server/
 ExecStart=/opt/kubearmor-relay-server/kubearmor-relay-server
-{{- if .UseSystemdAppend }}
+{{- if gt .SystemdVersion 240 }}
 StandardOutput=append:/opt/kubearmor-relay-server/kubearmor-relay-server.log
 StandardError=append:/opt/kubearmor-relay-server/kubearmor-relay-server-err.log
 {{- else }}
@@ -16,6 +16,19 @@ StandardError=file:/opt/kubearmor-relay-server/kubearmor-relay-server-err.log
 {{- end }}
 Restart=always
 RestartSec=10
+
+CPUQuota={{ .CPUQuota | default "5%" }}
+MemoryMax={{ .MemoryMax | default "100M" }}
+
+{{- if gt .SystemdVersion 241 }}
+MemoryHigh={{ .MemoryHigh | default "80M" }}
+{{- end }}
+
+{{- if gt .SystemdVersion 241 }}
+CPUWeight=50
+{{- end }}
+
+OOMPolicy=kill
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/onboard/templates/systemdTemplates/sia.service
+++ b/pkg/onboard/templates/systemdTemplates/sia.service
@@ -7,7 +7,7 @@ User=root
 KillMode=control-group
 WorkingDirectory=/opt/accuknox-shared-informer-agent/
 ExecStart=/opt/accuknox-shared-informer-agent/shared-informer-agent
-{{- if .UseSystemdAppend }}
+{{- if gt .SystemdVersion 240 }}
 StandardOutput=append:/opt/accuknox-shared-informer-agent/accuknox-shared-informer-agent.log
 StandardError=append:/opt/accuknox-shared-informer-agent/accuknox-shared-informer-agent-err.log
 {{- else }}
@@ -16,5 +16,19 @@ StandardError=file:/opt/accuknox-shared-informer-agent/accuknox-shared-informer-
 {{- end }}
 Restart=always
 RestartSec=10
+
+CPUQuota={{ .CPUQuota | default "5%" }}
+MemoryMax={{ .MemoryMax | default "100M" }}
+
+{{- if gt .SystemdVersion 241 }}
+MemoryHigh={{ .MemoryHigh | default "80M" }}
+{{- end }}
+
+{{- if gt .SystemdVersion 241 }}
+CPUWeight=50
+{{- end }}
+
+OOMPolicy=kill
+
 [Install]
 WantedBy=multi-user.target

--- a/pkg/onboard/templates/systemdTemplates/spire-agent.service
+++ b/pkg/onboard/templates/systemdTemplates/spire-agent.service
@@ -9,7 +9,7 @@ User=root
 KillMode=control-group
 WorkingDirectory=/opt/spire-agent/
 ExecStart=/opt/spire-agent/spire-agent run
-{{- if .UseSystemdAppend }}
+{{- if gt .SystemdVersion 240 }}
 StandardOutput=append:/opt/spire-agent/spire-agent.log
 StandardError=append:/opt/spire-agent/spire-agent-err.log
 {{- else }}
@@ -18,5 +18,19 @@ StandardError=file:/opt/spire-agent/spire-agent-err.log
 {{- end }}
 Restart=always
 RestartSec=10
+
+CPUQuota={{ .CPUQuota | default "5%" }}
+MemoryMax={{ .MemoryMax | default "100M" }}
+
+{{- if gt .SystemdVersion 241 }}
+MemoryHigh={{ .MemoryHigh | default "80M" }}
+{{- end }}
+
+{{- if gt .SystemdVersion 241 }}
+CPUWeight=50
+{{- end }}
+
+OOMPolicy=kill
+
 [Install]
 WantedBy=multi-user.target

--- a/pkg/onboard/templates/systemdTemplates/sumengine.service
+++ b/pkg/onboard/templates/systemdTemplates/sumengine.service
@@ -11,7 +11,7 @@ User=root
 KillMode=control-group
 WorkingDirectory=/opt/accuknox-sumengine/
 ExecStart=/opt/accuknox-sumengine/sumengine --config conf/config.yaml --kmux-config kmux-config.yaml
-{{- if .UseSystemdAppend }}
+{{- if gt .SystemdVersion 240 }}
 StandardOutput=append:/opt/accuknox-sumengine/accuknox-sumengine.log
 StandardError=append:/opt/accuknox-sumengine/accuknox-sumengine-err.log
 {{- else }}
@@ -20,6 +20,19 @@ StandardError=file:/opt/accuknox-sumengine/accuknox-sumengine-err.log
 {{- end }}
 Restart=always
 RestartSec=10
+
+CPUQuota={{ .CPUQuota | default "5%" }}
+MemoryMax={{ .MemoryMax | default "100M" }}
+
+{{- if gt .SystemdVersion 241 }}
+MemoryHigh={{ .MemoryHigh | default "80M" }}
+{{- end }}
+
+{{- if gt .SystemdVersion 241 }}
+CPUWeight=50
+{{- end }}
+
+OOMPolicy=kill
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/onboard/templates/systemdTemplates/vm-adapter.service
+++ b/pkg/onboard/templates/systemdTemplates/vm-adapter.service
@@ -7,7 +7,7 @@ User=root
 KillMode=control-group
 WorkingDirectory=/opt/kubearmor-vm-adapter/
 ExecStart=/opt/kubearmor-vm-adapter/kubearmor-vm-adapter
-{{- if .UseSystemdAppend }}
+{{- if gt .SystemdVersion 240 }}
 StandardOutput=append:/opt/kubearmor-vm-adapter/kubearmor-vm-adapter.log
 StandardError=append:/opt/kubearmor-vm-adapter/kubearmor-vm-adapter-err.log
 {{- else }}
@@ -16,6 +16,19 @@ StandardError=file:/opt/kubearmor-vm-adapter/kubearmor-vm-adapter-err.log
 {{- end }}
 Restart=always
 RestartSec=10
+
+CPUQuota={{ .CPUQuota | default "5%" }}
+MemoryMax={{ .MemoryMax | default "100M" }}
+
+{{- if gt .SystemdVersion 241 }}
+MemoryHigh={{ .MemoryHigh | default "80M" }}
+{{- end }}
+
+{{- if gt .SystemdVersion 241 }}
+CPUWeight=50
+{{- end }}
+
+OOMPolicy=kill
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/onboard/types.go
+++ b/pkg/onboard/types.go
@@ -106,7 +106,7 @@ type ClusterConfig struct {
 
 	CIDR string `json:"cidr,omitempty"`
 
-	TemplateFuncs map[string]interface{} `json:"-"`
+	TemplateFuncs map[string]any `json:"-"`
 
 	// internal
 	composeCmd     string
@@ -158,6 +158,9 @@ type ClusterConfig struct {
 	Parallel  int       `json:"parallel,omitempty"`
 
 	AdditionalArgs map[string]any `json:"additional_args,omitempty"`
+
+	KaResource     ResourceConfig `json:"kubearmor_resource,omitempty"`
+	AgentsResource ResourceConfig `json:"agents_resource,omitempty"`
 }
 
 type AccessKey struct {
@@ -437,4 +440,10 @@ type SplunkConfig struct {
 	Index       string
 	Certificate string
 	SkipTls     bool
+}
+
+type ResourceConfig struct {
+	CPUQuota   int64
+	MemoryMax  int64
+	MemoryHigh int64
 }


### PR DESCRIPTION
**JIRA:** [CNAPP-23379](https://accu-knox.atlassian.net/browse/CNAPP-23379)


This PR contains the following changes:
- Add resource limit for agents and kubearmor
- default cpu 5% with memory 100M for agents
- default cpu 5% with memory 300M for kubearmor

```
      --agents.cpu-quota int                cpu quota for agents in percentage. eg: 5 (default 3)
      --agents.memory-high int              memory quota for agents in MB. eg: 80 (default 80)
      --agents.memory-max int               memory max for agents in MB. eg: 100 (default 100)
      --kubearmor.cpu-quota int             cpu quota for kubearmor in percentage. eg: 5 (default 5)
      --kubearmor.memory-high int           memory quota for kubearmor in MB. eg: 240 (default 240)
      --kubearmor.memory-max int            memory max for kubearmor in MB. eg: 300 (default 300)
```

[CNAPP-23379]: https://accu-knox.atlassian.net/browse/CNAPP-23379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ