### PR TITLE
feat(proxy): add proxy related configs

### DIFF
--- a/cmd/deboard-vm-node.go
+++ b/cmd/deboard-vm-node.go
@@ -45,10 +45,10 @@ var deboardNodeCmd = &cobra.Command{
 			if err != nil && os.IsPermission(err) {
 				logger.Warn("Please remove any remaining resources at %s", configPath)
 			} else if err != nil {
-				return fmt.Errorf(color.RedString("Failed to deboard worker node: %s", err.Error()))
+				return fmt.Errorf("%s", color.RedString("Failed to deboard worker node: %s", err.Error()))
 			}
 		default:
-			return fmt.Errorf(color.RedString("vm mode: %s invalid, accepted values (docker/systemd)", vmMode))
+			return fmt.Errorf("%s", color.RedString("vm mode: %s invalid, accepted values (docker/systemd)", vmMode))
 		}
 		if disableVMScan {
 			logger.Info1("Removing RRA installation if it exists")

--- a/cmd/onboard-vm-cp-node.go
+++ b/cmd/onboard-vm-cp-node.go
@@ -54,6 +54,8 @@ var (
 
 	enableHostPolicyDiscovery bool
 	enableHardeningAgent      bool
+
+	proxy onboard.Proxy
 )
 
 // cpNodeCmd represents the init command
@@ -128,7 +130,7 @@ var cpNodeCmd = &cobra.Command{
 			peaImage, feederImage, rmqImage, sumEngineImage, hardeningAgentImage, spireAgentImage, waitForItImage, discoverImage, nodeAddr, dryRun,
 			false, deployRMQ, imagePullPolicy, visibility, hostVisibility, sumEngineVisibility, audit, block, hostAudit, hostBlock,
 			alertThrottling, maxAlertPerSec, throttleSec,
-			cidr, secureContainers, skipBTF, systemMonitorPath, rmqAddress, deploySumEngine, registry, registryConfigPath, insecure, plainHTTP, preserveUpstream, topicPrefix, rmqConnectionName, sumEngineCronTime, tls, enableHostPolicyDiscovery, splunk, nodeStateRefreshTime, spireEnabled, spireCert, logRotate, parallel, enableHardeningAgent, releaseFile)
+			cidr, secureContainers, skipBTF, systemMonitorPath, rmqAddress, deploySumEngine, registry, registryConfigPath, insecure, plainHTTP, preserveUpstream, topicPrefix, rmqConnectionName, sumEngineCronTime, tls, enableHostPolicyDiscovery, splunk, nodeStateRefreshTime, spireEnabled, spireCert, logRotate, parallel, enableHardeningAgent, releaseFile, proxy)
 		if err != nil {
 			errConfig := onboard.DumpConfig(vmConfig, configDumpPath)
 			if errConfig != nil {
@@ -242,6 +244,12 @@ func init() {
 	cpNodeCmd.PersistentFlags().BoolVar(&enableHostPolicyDiscovery, "enable-host-policy-discovery", false, "to enable host policy auto-discovery")
 
 	cpNodeCmd.PersistentFlags().BoolVar(&enableHardeningAgent, "enable-hardening-agent", false, "to enable hardening agent")
+
+	cpNodeCmd.PersistentFlags().BoolVar(&proxy.Enabled, "proxy", false, "bypass spire and use proxy")
+
+	cpNodeCmd.PersistentFlags().StringVar(&proxy.Address, "proxy-address", "", "proxy address")
+
+	cpNodeCmd.PersistentFlags().StringArrayVar(&proxy.ExtraArgs, "proxy-args", []string{}, "extra env variables for proxy")
 
 	err := cpNodeCmd.MarkPersistentFlagRequired("pps-host")
 	if err != nil {

--- a/cmd/onboard-vm-node.go
+++ b/cmd/onboard-vm-node.go
@@ -108,7 +108,7 @@ var joinNodeCmd = &cobra.Command{
 			peaImage, feederImage, rmqImage, sumEngineImage, hardeningAgentImage, spireAgentImage, waitForItImage, discoverImage, nodeAddr, dryRun,
 			true, deployRMQ, imagePullPolicy, visibility, hostVisibility, sumEngineVisibility, audit, block, hostAudit, hostBlock,
 			alertThrottling, maxAlertPerSec, throttleSec,
-			cidr, secureContainers, skipBTF, systemMonitorPath, rmqAddress, deploySumEngine, registry, registryConfigPath, insecure, plainHTTP, preserveUpstream, topicPrefix, rmqConnectionName, sumEngineCronTime, tls, enableHostPolicyDiscovery, splunk, nodeStateRefreshTime, spireEnabled, spireCert, logRotate, parallel, enableHardeningAgent, releaseFile)
+			cidr, secureContainers, skipBTF, systemMonitorPath, rmqAddress, deploySumEngine, registry, registryConfigPath, insecure, plainHTTP, preserveUpstream, topicPrefix, rmqConnectionName, sumEngineCronTime, tls, enableHostPolicyDiscovery, splunk, nodeStateRefreshTime, spireEnabled, spireCert, logRotate, parallel, enableHardeningAgent, releaseFile, proxy)
 		if err != nil {
 			errConfig := onboard.DumpConfig(vmConfigs, configDumpPath)
 			if errConfig != nil {

--- a/pkg/common/release.json
+++ b/pkg/common/release.json
@@ -1992,6 +1992,27 @@
       "rra_tag": "v0.5.0",
       "rra_image": "accuknox/rra"
     },
+    "v0.11.12-proxy": {
+      "creation_time": "1756811879",
+      "kubearmor_tag": "v1.6.5",
+      "kubearmor_relay_tag": "v0.0.4",
+      "kubearmor_vm_adapter_tag": "v0.1.15",
+      "spire_agent_tag": "v2.0.12",
+      "sia_tag": "v0.8.10-proxy",
+      "sia_image": "public.ecr.aws/k9v9d5v2/shared-informer-agent",
+      "pea_tag": "v0.8.1-proxy",
+      "pea_image": "public.ecr.aws/k9v9d5v2/policy-enforcement-agent",
+      "feeder_service_tag": "v0.10.2-proxy",
+      "feeder_service_image": "public.ecr.aws/k9v9d5v2/feeder-service",
+      "discover_tag": "v0.3.18",
+      "discover_image": "public.ecr.aws/k9v9d5v2/discovery-engine-discover",
+      "sumengine_tag": "v0.3.18",
+      "sumengine_image": "public.ecr.aws/k9v9d5v2/discovery-engine-sumengine",
+      "hardening_agent_tag": "v0.3.18",
+      "hardening_agent_image": "public.ecr.aws/k9v9d5v2/discovery-engine-hardening",
+      "rra_tag": "v0.5.0",
+      "rra_image": "accuknox/rra"
+    },
     "v0.11.12": {
       "creation_time": "1756811879",
       "kubearmor_tag": "v1.6.5",

--- a/pkg/onboard/cpNode.go
+++ b/pkg/onboard/cpNode.go
@@ -24,7 +24,14 @@ type agentConfigMeta struct {
 	kmuxConfigFileName       string
 }
 
+type Proxy struct {
+	Enabled   bool
+	Address   string
+	ExtraArgs []string
+}
+
 func InitCPNodeConfig(cc ClusterConfig, joinToken, spireHost, ppsHost, knoxGateway, spireTrustBundle, secretDir string, enableLogs bool) *InitConfig {
+	cc.JoinToken = joinToken
 	return &InitConfig{
 		ClusterConfig: cc,
 		JoinToken:     joinToken,
@@ -129,6 +136,9 @@ func (ic *InitConfig) CreateBaseTemplateConfig() error {
 		SpireCert:      ic.SpireCert,
 		SpireEnabled:   ic.SpireEnabled,
 		SpireSecretDir: ic.SpireSecretDir,
+		ProxyEnabled:   ic.Proxy.Enabled,
+		ProxyAddress:   ic.Proxy.Address,
+		ProxyExtraArgs: ic.Proxy.ExtraArgs,
 	}
 	return nil
 }

--- a/pkg/onboard/cpNodeSD.go
+++ b/pkg/onboard/cpNodeSD.go
@@ -108,6 +108,10 @@ func (ic *InitConfig) InitializeControlPlaneSD() error {
 			continue
 		}
 
+		if ic.Proxy.Enabled && obj.AgentName == cm.SpireAgent {
+			continue
+		}
+
 		if obj.ConfigFilePath != "" {
 			// copy template args
 			tcArgs := ic.TCArgs

--- a/pkg/onboard/onboard.go
+++ b/pkg/onboard/onboard.go
@@ -21,7 +21,7 @@ func CreateClusterConfig(clusterType ClusterType, userConfigPath string, vmMode 
 	imagePullPolicy, visibility, hostVisibility, sumengineViz, audit, block, hostAudit, hostBlock string,
 	alertThrottling bool, maxAlertPerSec, throttleSec int,
 	cidr string, secureContainers, skipBTF bool, systemMonitorPath string,
-	rmqAddr string, deploySumengine bool, registry, registryConfigPath string, insecureRegistryConnection, httpRegistryConnection, preserveUpstream bool, topicPrefix, connName, sumEngineCronTime string, tls TLS, enableHostPolicyDiscovery bool, splunk SplunkConfig, stateRefreshTime int, spireEnabled, spireCert bool, logRotate string, parallel int, hardeningService bool, releaseFile string) (*ClusterConfig, error) {
+	rmqAddr string, deploySumengine bool, registry, registryConfigPath string, insecureRegistryConnection, httpRegistryConnection, preserveUpstream bool, topicPrefix, connName, sumEngineCronTime string, tls TLS, enableHostPolicyDiscovery bool, splunk SplunkConfig, stateRefreshTime int, spireEnabled, spireCert bool, logRotate string, parallel int, hardeningService bool, releaseFile string, proxy Proxy) (*ClusterConfig, error) {
 
 	cc := new(ClusterConfig)
 
@@ -388,6 +388,8 @@ func CreateClusterConfig(clusterType ClusterType, userConfigPath string, vmMode 
 	cc.Splunk = splunk
 
 	cc.NodeStateRefreshTime = stateRefreshTime
+
+	cc.Proxy = proxy
 
 	return cc, nil
 }

--- a/pkg/onboard/systemdUtils.go
+++ b/pkg/onboard/systemdUtils.go
@@ -335,6 +335,10 @@ func (cc *ClusterConfig) placeServiceFiles() error {
 		"WorkerNode":     cc.WorkerNode,
 		"SystemdVersion": getSystemdVersion(),
 		"ReleaseVersion": cc.AgentsVersion,
+		"ProxyEnabled":   cc.Proxy.Enabled,
+		"ProxyAddress":   cc.Proxy.Address,
+		"ProxyExtraArgs": cc.Proxy.ExtraArgs,
+		"JoinToken":      cc.JoinToken,
 	}
 
 	if cc.AdditionalArgs != nil {
@@ -544,6 +548,10 @@ func (cc *ClusterConfig) SystemdInstall() error {
 			continue
 		}
 		if obj.AgentImage == "" || obj.PackageName == "" {
+			continue
+		}
+
+		if cc.Proxy.Enabled && obj.AgentName == cm.SpireAgent {
 			continue
 		}
 

--- a/pkg/onboard/templates/docker-compose_cp-node.yaml
+++ b/pkg/onboard/templates/docker-compose_cp-node.yaml
@@ -1,10 +1,13 @@
 volumes:
+{{- if ne .ProxyEnabled true }}
   spire-vol:
     name: spire-vol
+{{- end }}
   kubearmor-init-vol:
     name: kubearmor-init-vol
 
 services:
+{{- if ne .ProxyEnabled true }}
   spire-agent:
     profiles:
       - "spire-agent"
@@ -54,7 +57,7 @@ services:
       accuknox-net:
         aliases:
           - wait-for-it
-
+{{- end }}
   kubearmor-init:
     profiles:
       - "kubearmor-only"
@@ -206,8 +209,10 @@ services:
     profiles:
       - "accuknox-agents"
     depends_on:
+      {{- if ne .ProxyEnabled true }}
       wait-for-it:
         condition: service_completed_successfully
+      {{- end }}
       kubearmor:
         condition: service_started
       {{- if not .TlsEnabled }}
@@ -220,6 +225,10 @@ services:
     command: ["-config-path", "/opt/sia/"]
     labels:
       app: shared-informer-agent
+    {{- if .ProxyEnabled }}
+    environment:
+    - "JOIN_TOKEN={{.JoinToken}}"
+    {{- end }}
     volumes:
       - "{{.ConfigPath}}:/opt"
       - "/var/run:/var/run:ro"
@@ -236,8 +245,10 @@ services:
     profiles:
       - "accuknox-agents"
     depends_on:
+      {{- if ne .ProxyEnabled true }}
       wait-for-it:
         condition: service_completed_successfully
+      {{- end }}
       kubearmor-relay-server:
         condition: service_started
       summary-engine:
@@ -275,7 +286,14 @@ services:
       - "IGNORE_SUMMARY_EVENTS=Network:AF_UNIX,AF_NETLINK"
 
       - "SPIRE_AGENT_URL=unix:///var/run/spire/agent.sock"
+      {{- if .ProxyEnabled }}
+      - "SPIRE_ENABLED=false"
+      - "PROXY_ENABLED={{.ProxyEnabled}}"
+      - "PROXY_ADDRESS={{.ProxyAddress}}"
+      - "JOIN_TOKEN={{.JoinToken}}
+      {{- else }}
       - "SPIRE_ENABLED=true"
+      {{- end }}
       - "TLS_ENABLED={{.TlsEnabled}}"
       - "TLS_CERT_FILE=/opt/cert/encoded.pem"
       - "RABBITMQ_ENABLED={{.TlsEnabled}}"
@@ -300,8 +318,10 @@ services:
     profiles:
       - "accuknox-agents"
     depends_on:
+      {{- if ne .ProxyEnabled true }}
       wait-for-it:
         condition: service_completed_successfully
+      {{- end }}
       kubearmor-relay-server:
         condition: service_started
     container_name: policy-enforcement-agent
@@ -314,6 +334,10 @@ services:
       - "{{.ConfigPath}}:/opt"
       # for spire socket
       - "/var/run:/var/run:ro"
+    {{- if .ProxyEnabled }}
+    environment:
+    - "JOIN_TOKEN={{.JoinToken}}"
+    {{- end }}
     restart: always
     ports:
       - "32770:32770"

--- a/pkg/onboard/templates/pea-config.yaml
+++ b/pkg/onboard/templates/pea-config.yaml
@@ -6,7 +6,11 @@ application:
   name: policy-enf-agent
 
 spire:
+  {{ if .ProxyEnabled }}
+  enable: false
+  {{ else }}
   enable: true
+  {{ end }}
   agent: "unix:///var/run/spire/agent.sock"
 
 endpoint:
@@ -48,3 +52,7 @@ reconciler:
   interval: 30m
 
 log-level: info
+
+proxy:
+  enabled: {{.ProxyEnabled}}
+  address: {{.ProxyAddress}}

--- a/pkg/onboard/templates/sia-config.yaml
+++ b/pkg/onboard/templates/sia-config.yaml
@@ -1,5 +1,9 @@
 spire:
+  {{ if .ProxyEnabled }}
+  enable: false
+  {{ else }}
   enable: true
+  {{ end }}
   agent: "unix:///var/run/spire/agent.sock"
 
 {{- if trimPrefix "v" .ReleaseVersion | semverCompare "<0.5.0" }}
@@ -30,3 +34,7 @@ tls:
   state-topic: {{.StateEventTopic}}
 
 deployMode: "vm"
+
+proxy:
+  enabled: {{.ProxyEnabled}}
+  address: {{.ProxyAddress}}

--- a/pkg/onboard/templates/systemdTemplates/feeder-service-env
+++ b/pkg/onboard/templates/systemdTemplates/feeder-service-env
@@ -9,7 +9,12 @@ KMUX_LOGS_ENABLED={{.EnableLogs}}
 KMUX_CONFIG_PATH={{.KmuxConfigPath}}
 IGNORE_SUMMARY_EVENTS="Network:AF_UNIX,AF_NETLINK"
 SPIRE_AGENT_URL="unix:///var/run/spire/agent.sock"
+{{ if .ProxyEnabled }}
+SPIRE_ENABLED=false
+{{ else }}
 SPIRE_ENABLED=true
+{{ end }}
+
 DISCOVERYENGINE_ENABLED=true
 DISCOVERYENGINE_VERSION=2
 TLS_CERT_FILE="/opt/cert/encoded.pem"
@@ -26,3 +31,6 @@ DISCOVERYENGINE_POLICY_ENABLED=true
 KMUX_CONFIG_POLICY={{.PolicyKmuxConfig}}
 KMUX_CONFIG_SUMMARY={{.SummaryKmuxConfig}}
 LOG_LEVEL="INFO"
+
+PROXY_ENABLED={{.ProxyEnabled}}
+PROXY_ADDRESS="{{.ProxyAddress}}"

--- a/pkg/onboard/templates/systemdTemplates/feeder-service.service
+++ b/pkg/onboard/templates/systemdTemplates/feeder-service.service
@@ -7,6 +7,12 @@ User=root
 KillMode=control-group
 WorkingDirectory=/opt/accuknox-feeder-service/
 EnvironmentFile=/opt/accuknox-feeder-service/conf/env
+{{- if .ProxyEnabled }}
+{{- range .ProxyExtraArgs }}
+Environment={{ . }}
+{{- end }}
+Environment="JOIN_TOKEN={{ .JoinToken }}"
+{{- end }}
 {{- if gt .SystemdVersion 240 }}
 StandardOutput=append:/opt/accuknox-feeder-service/accuknox-feeder-service.log
 StandardError=append:/opt/accuknox-feeder-service/accuknox-feeder-service-err.log

--- a/pkg/onboard/templates/systemdTemplates/pea.service
+++ b/pkg/onboard/templates/systemdTemplates/pea.service
@@ -7,6 +7,12 @@ User=root
 KillMode=control-group
 WorkingDirectory=/opt/accuknox-policy-enforcement-agent/
 ExecStart=/opt/accuknox-policy-enforcement-agent/accuknox-policy-enforcement-agent
+{{- if .ProxyEnabled }}
+{{- range .ProxyExtraArgs }}
+Environment={{ . }}
+{{- end }}
+Environment="JOIN_TOKEN={{ .JoinToken }}"
+{{- end }}
 {{- if gt .SystemdVersion 240 }}
 StandardOutput=append:/opt/accuknox-policy-enforcement-agent/accuknox-policy-enforcement-agent.log
 StandardError=append:/opt/accuknox-policy-enforcement-agent/accuknox-policy-enforcement-agent-err.log

--- a/pkg/onboard/templates/systemdTemplates/sia.service
+++ b/pkg/onboard/templates/systemdTemplates/sia.service
@@ -7,6 +7,12 @@ User=root
 KillMode=control-group
 WorkingDirectory=/opt/accuknox-shared-informer-agent/
 ExecStart=/opt/accuknox-shared-informer-agent/shared-informer-agent
+{{- if .ProxyEnabled }}
+{{- range .ProxyExtraArgs }}
+Environment={{ . }}
+{{- end }}
+Environment="JOIN_TOKEN={{ .JoinToken }}"
+{{- end }}
 {{- if gt .SystemdVersion 240 }}
 StandardOutput=append:/opt/accuknox-shared-informer-agent/accuknox-shared-informer-agent.log
 StandardError=append:/opt/accuknox-shared-informer-agent/accuknox-shared-informer-agent-err.log

--- a/pkg/onboard/types.go
+++ b/pkg/onboard/types.go
@@ -148,8 +148,9 @@ type ClusterConfig struct {
 	Splunk               SplunkConfig `json:"splunk,omitempty"`
 	NodeStateRefreshTime int          `json:"node_state_refresh_time,omitempty"`
 
-	SpireEnabled bool `json:"spire_enabled,omitempty"`
-	SpireCert    bool `json:"spire_cert,omitempty"`
+	SpireEnabled bool   `json:"spire_enabled,omitempty"`
+	SpireCert    bool   `json:"spire_cert,omitempty"`
+	JoinToken    string `json:"join_token,omitempty"`
 	// logrotateString
 	LogRotateTemplateString string `json:"-"`
 	LogRotate               string `json:"logrotate,omitempty"`
@@ -161,6 +162,8 @@ type ClusterConfig struct {
 
 	KaResource     ResourceConfig `json:"kubearmor_resource,omitempty"`
 	AgentsResource ResourceConfig `json:"agents_resource,omitempty"`
+
+	Proxy Proxy `json:"proxy,omitempty"`
 }
 
 type AccessKey struct {
@@ -336,6 +339,10 @@ type TemplateConfigArgs struct {
 	SpireCert    bool `json:"spire_cert,omitempty"`
 
 	AccessKey AccessKey `json:"access_key,omitempty"`
+
+	ProxyEnabled   bool     `json:"proxy_enabled,omitempty"`
+	ProxyAddress   string   `json:"proxy_address,omitempty"`
+	ProxyExtraArgs []string `json:"proxy_extra_env,omitempty"`
 }
 
 type KmuxConfigTemplateArgs struct {


### PR DESCRIPTION
Add support for proxy based onboarding. 
Command should be 
```
sudo knoxctl onboard vm cp-node \
  --version v0.11.12-proxy \
  --join-token=<join_token> \
  --spire-host=spire.<env>.accuknox.com \
  --pps-host=pps.<env>.accuknox.com \
  --knox-gateway=knox-gw.<env>.accuknox.com:3000 \
  --vm-mode=systemd \
  --proxy \
  --proxy-address <saas_proxy_address> \
  --proxy-args "http_proxy=http://192.168.0.200:3128" \
  --proxy-args "https_proxy=http://192.168.0.200:3128" \
  --proxy-args "HTTP_PROXY=http://192.168.0.200:3128" \
  --proxy-args "HTTPS_PROXY=http://192.168.0.200:3128" \
  --proxy-args "no_proxy=localhost,127.0.0.1,172.17.0.1" \
  --proxy-args "NO_PROXY=localhost,127.0.0.1,172.17.0.1" 
```

currently it will only work with `v0.11.12-proxy` version