### PR TITLE
fix(proxy): add proxy variables even if proxy is not enabled

### DIFF
--- a/cmd/onboard-vm-cp-node.go
+++ b/cmd/onboard-vm-cp-node.go
@@ -245,12 +245,6 @@ func init() {
 
 	cpNodeCmd.PersistentFlags().BoolVar(&enableHardeningAgent, "enable-hardening-agent", false, "to enable hardening agent")
 
-	cpNodeCmd.PersistentFlags().BoolVar(&proxy.Enabled, "proxy", false, "bypass spire and use proxy")
-
-	cpNodeCmd.PersistentFlags().StringVar(&proxy.Address, "proxy-address", "", "proxy address")
-
-	cpNodeCmd.PersistentFlags().StringArrayVar(&proxy.ExtraArgs, "proxy-args", []string{}, "extra env variables for proxy")
-
 	err := cpNodeCmd.MarkPersistentFlagRequired("pps-host")
 	if err != nil {
 		fmt.Println(err)

--- a/cmd/onboard-vm.go
+++ b/cmd/onboard-vm.go
@@ -217,5 +217,11 @@ func init() {
 	onboardVMCmd.PersistentFlags().Int64Var(&agentsResource.MemoryMax, "agents.memory-max", 100, "memory max for agents in MB. eg: 100")
 	onboardVMCmd.PersistentFlags().Int64Var(&agentsResource.MemoryHigh, "agents.memory-high", 80, "memory quota for agents in MB. eg: 80")
 
+	onboardVMCmd.PersistentFlags().BoolVar(&proxy.Enabled, "proxy", false, "bypass spire and use proxy")
+
+	onboardVMCmd.PersistentFlags().StringVar(&proxy.Address, "proxy-address", "", "proxy address")
+
+	onboardVMCmd.PersistentFlags().StringArrayVar(&proxy.ExtraArgs, "proxy-args", []string{}, "extra env variables for proxy")
+
 	onboardCmd.AddCommand(onboardVMCmd)
 }

--- a/pkg/onboard/node.go
+++ b/pkg/onboard/node.go
@@ -156,6 +156,9 @@ func (jc *JoinConfig) CreateBaseNodeConfig() error {
 		NodeStateRefreshTime: jc.NodeStateRefreshTime,
 		SpireEnabled:         jc.SpireEnabled,
 		SpireCert:            jc.SpireCert,
+		ProxyExtraArgs:       jc.Proxy.ExtraArgs,
+		ProxyEnabled:         jc.Proxy.Enabled,
+		ProxyAddress:         jc.Proxy.Address,
 	}
 
 	jc.TCArgs.PoliciesKmuxConfig = common.KmuxPoliciesFileName

--- a/pkg/onboard/templates/docker-compose_cp-node.yaml
+++ b/pkg/onboard/templates/docker-compose_cp-node.yaml
@@ -225,9 +225,13 @@ services:
     command: ["-config-path", "/opt/sia/"]
     labels:
       app: shared-informer-agent
-    {{- if .ProxyEnabled }}
     environment:
+    - "test=true"
+    {{- if .ProxyEnabled }}
     - "JOIN_TOKEN={{.JoinToken}}"
+    {{- end }}
+    {{- range .ProxyExtraArgs }}
+    - {{ . }}
     {{- end }}
     volumes:
       - "{{.ConfigPath}}:/opt"
@@ -294,6 +298,9 @@ services:
       {{- else }}
       - "SPIRE_ENABLED=true"
       {{- end }}
+      {{- range .ProxyExtraArgs }}
+      - {{ . }}
+      {{- end }}
       - "TLS_ENABLED={{.TlsEnabled}}"
       - "TLS_CERT_FILE=/opt/cert/encoded.pem"
       - "RABBITMQ_ENABLED={{.TlsEnabled}}"
@@ -334,9 +341,13 @@ services:
       - "{{.ConfigPath}}:/opt"
       # for spire socket
       - "/var/run:/var/run:ro"
-    {{- if .ProxyEnabled }}
     environment:
+    - "test=true"
+    {{- if .ProxyEnabled  }}
     - "JOIN_TOKEN={{.JoinToken}}"
+    {{- end }}
+    {{- range .ProxyExtraArgs }}
+    - {{ . }}
     {{- end }}
     restart: always
     ports:

--- a/pkg/onboard/templates/docker-compose_node.yaml
+++ b/pkg/onboard/templates/docker-compose_node.yaml
@@ -146,6 +146,14 @@ services:
     container_name: kubearmor-vm-adapter
     image: "{{.KubeArmorVMAdapterImage}}"
     pull_policy: "{{.ImagePullPolicy}}"
+    environment:
+    - "test=true"
+    {{- if .ProxyEnabled  }}
+    - "JOIN_TOKEN={{.JoinToken}}"
+    {{- end }}
+    {{- range .ProxyExtraArgs }}
+    - {{ . }}
+    {{- end }}
     command:
       - "--kubearmor-addr={{.KubeArmorURL}}"
       - "--relay-server-addr={{.RelayServerURL}}"
@@ -199,6 +207,14 @@ services:
     command: ["--config", "/opt/sumengine/config.yaml", "--kmux-config", "/opt/sumengine/kmux-config.yaml"]
     labels:
       app: sumengine
+    environment:
+    - "test=true"
+    {{- if .ProxyEnabled  }}
+    - "JOIN_TOKEN={{.JoinToken}}"
+    {{- end }}
+    {{- range .ProxyExtraArgs }}
+    - {{ . }}
+    {{- end }}
     volumes:
       - "{{.ConfigPath}}:/opt"
       {{- if .SpireEnabled }}

--- a/pkg/onboard/templates/systemdTemplates/feeder-service.service
+++ b/pkg/onboard/templates/systemdTemplates/feeder-service.service
@@ -7,10 +7,10 @@ User=root
 KillMode=control-group
 WorkingDirectory=/opt/accuknox-feeder-service/
 EnvironmentFile=/opt/accuknox-feeder-service/conf/env
-{{- if .ProxyEnabled }}
 {{- range .ProxyExtraArgs }}
 Environment={{ . }}
 {{- end }}
+{{- if .ProxyEnabled }}
 Environment="JOIN_TOKEN={{ .JoinToken }}"
 {{- end }}
 {{- if gt .SystemdVersion 240 }}

--- a/pkg/onboard/templates/systemdTemplates/pea.service
+++ b/pkg/onboard/templates/systemdTemplates/pea.service
@@ -7,10 +7,10 @@ User=root
 KillMode=control-group
 WorkingDirectory=/opt/accuknox-policy-enforcement-agent/
 ExecStart=/opt/accuknox-policy-enforcement-agent/accuknox-policy-enforcement-agent
-{{- if .ProxyEnabled }}
 {{- range .ProxyExtraArgs }}
 Environment={{ . }}
 {{- end }}
+{{- if .ProxyEnabled }}
 Environment="JOIN_TOKEN={{ .JoinToken }}"
 {{- end }}
 {{- if gt .SystemdVersion 240 }}

--- a/pkg/onboard/templates/systemdTemplates/sia.service
+++ b/pkg/onboard/templates/systemdTemplates/sia.service
@@ -7,10 +7,10 @@ User=root
 KillMode=control-group
 WorkingDirectory=/opt/accuknox-shared-informer-agent/
 ExecStart=/opt/accuknox-shared-informer-agent/shared-informer-agent
-{{- if .ProxyEnabled }}
 {{- range .ProxyExtraArgs }}
 Environment={{ . }}
 {{- end }}
+{{- if .ProxyEnabled }}
 Environment="JOIN_TOKEN={{ .JoinToken }}"
 {{- end }}
 {{- if gt .SystemdVersion 240 }}

--- a/pkg/onboard/templates/systemdTemplates/sumengine.service
+++ b/pkg/onboard/templates/systemdTemplates/sumengine.service
@@ -11,6 +11,14 @@ User=root
 KillMode=control-group
 WorkingDirectory=/opt/accuknox-sumengine/
 ExecStart=/opt/accuknox-sumengine/sumengine --config conf/config.yaml --kmux-config kmux-config.yaml
+
+{{- range .ProxyExtraArgs }}
+Environment={{ . }}
+{{- end }}
+{{- if .ProxyEnabled }}
+Environment="JOIN_TOKEN={{ .JoinToken }}"
+{{- end }}
+
 {{- if gt .SystemdVersion 240 }}
 StandardOutput=append:/opt/accuknox-sumengine/accuknox-sumengine.log
 StandardError=append:/opt/accuknox-sumengine/accuknox-sumengine-err.log

--- a/pkg/onboard/templates/systemdTemplates/vm-adapter.service
+++ b/pkg/onboard/templates/systemdTemplates/vm-adapter.service
@@ -7,6 +7,14 @@ User=root
 KillMode=control-group
 WorkingDirectory=/opt/kubearmor-vm-adapter/
 ExecStart=/opt/kubearmor-vm-adapter/kubearmor-vm-adapter
+
+{{- range .ProxyExtraArgs }}
+Environment={{ . }}
+{{- end }}
+{{- if .ProxyEnabled }}
+Environment="JOIN_TOKEN={{ .JoinToken }}"
+{{- end }}
+
 {{- if gt .SystemdVersion 240 }}
 StandardOutput=append:/opt/kubearmor-vm-adapter/kubearmor-vm-adapter.log
 StandardError=append:/opt/kubearmor-vm-adapter/kubearmor-vm-adapter-err.log


### PR DESCRIPTION
This PR contains the following changes:
- add extra env variables even if proxy is not enabled
- add env variables to summary engine and vm-adapter
- add proxy to worker node
- add proxy config in docker based installation 