### PR TITLE
fix(systemd): configure cpu and memory only if explicitly set by user

### DIFF
--- a/cmd/onboard-vm.go
+++ b/cmd/onboard-vm.go
@@ -211,13 +211,13 @@ func init() {
 	onboardVMCmd.PersistentFlags().BoolVar(&printInspectOutput, "print-inspect", false, "print output of inspect command")
 
 	// resource config for agents and kubearmor
-	onboardVMCmd.PersistentFlags().Int64Var(&kaResource.CPUQuota, "kubearmor.cpu-quota", 5, "cpu quota for kubearmor in percentage. eg: 5")
-	onboardVMCmd.PersistentFlags().Int64Var(&kaResource.MemoryMax, "kubearmor.memory-max", 300, "memory max for kubearmor in MB. eg: 300")
-	onboardVMCmd.PersistentFlags().Int64Var(&kaResource.MemoryHigh, "kubearmor.memory-high", 240, "memory quota for kubearmor in MB. eg: 240")
+	onboardVMCmd.PersistentFlags().Int64Var(&kaResource.CPUQuota, "kubearmor.cpu-quota", 0, "cpu quota for kubearmor in percentage. eg: 25")
+	onboardVMCmd.PersistentFlags().Int64Var(&kaResource.MemoryMax, "kubearmor.memory-max", 0, "memory max for kubearmor in MB. eg: 600")
+	onboardVMCmd.PersistentFlags().StringVar(&kaResource.OOMPolicy, "kubearmor.oom-policy", "stop", "oom policy for kubearmor")
 
-	onboardVMCmd.PersistentFlags().Int64Var(&agentsResource.CPUQuota, "agents.cpu-quota", 5, "cpu quota for agents in percentage. eg: 5")
-	onboardVMCmd.PersistentFlags().Int64Var(&agentsResource.MemoryMax, "agents.memory-max", 100, "memory max for agents in MB. eg: 100")
-	onboardVMCmd.PersistentFlags().Int64Var(&agentsResource.MemoryHigh, "agents.memory-high", 80, "memory quota for agents in MB. eg: 80")
+	onboardVMCmd.PersistentFlags().Int64Var(&agentsResource.CPUQuota, "agents.cpu-quota", 0, "cpu quota for agents in percentage. eg: 10")
+	onboardVMCmd.PersistentFlags().Int64Var(&agentsResource.MemoryMax, "agents.memory-max", 0, "memory max for agents in MB. eg: 250")
+	onboardVMCmd.PersistentFlags().StringVar(&agentsResource.OOMPolicy, "agents.oom-policy", "stop", "oom policy for agents")
 
 	onboardVMCmd.PersistentFlags().BoolVar(&proxy.Enabled, "proxy", false, "bypass spire and use proxy")
 

--- a/pkg/onboard/cpNodeSD.go
+++ b/pkg/onboard/cpNodeSD.go
@@ -105,7 +105,7 @@ func (ic *InitConfig) InitializeControlPlaneSD() error {
 	logger.Info2(("Downloading agents..."))
 	err = ic.SystemdInstall()
 	if err != nil {
-		logger.Error("Installation failed!! Cleaning up downloaded assets...")
+		logger.Error("Installation failed!! Error: %v.\nCleaning up downloaded assets...", err)
 		// ignoring G104 - can't send nil in installation failed case
 		Deletedir(cm.DownloadDir)
 		DeboardSystemd(NodeType_ControlPlane) // #nosec G104

--- a/pkg/onboard/systemdUtils.go
+++ b/pkg/onboard/systemdUtils.go
@@ -370,14 +370,14 @@ func (cc *ClusterConfig) placeServiceFiles() error {
 			continue
 		}
 
-		configArgs["CPUQuota"] = fmt.Sprintf("%v%s", cc.AgentsResource.CPUQuota, "%")
-		configArgs["MemoryMax"] = fmt.Sprintf("%vM", cc.AgentsResource.MemoryMax)
-		configArgs["MemoryHigh"] = fmt.Sprintf("%vM", cc.AgentsResource.MemoryHigh)
+		if err := applyResourceConfig(configArgs, cc.AgentsResource); err != nil {
+			return err
+		}
 
 		if obj.AgentName == cm.KubeArmor {
-			configArgs["CPUQuota"] = fmt.Sprintf("%v%s", cc.KaResource.CPUQuota, "%")
-			configArgs["MemoryMax"] = fmt.Sprintf("%vM", cc.KaResource.MemoryMax)
-			configArgs["MemoryHigh"] = fmt.Sprintf("%vM", cc.KaResource.MemoryHigh)
+			if err := applyResourceConfig(configArgs, cc.KaResource); err != nil {
+				return err
+			}
 		}
 
 		if obj.ServiceTemplateString != "" {
@@ -994,4 +994,29 @@ func GetSystemdServiceStatus(name string) (string, error) {
 	}
 
 	return status, nil
+}
+
+func applyResourceConfig(configArgs map[string]any, res ResourceConfig) error {
+
+	if res.MemoryMax < 0 || res.CPUQuota < 0 {
+		return fmt.Errorf("MemoryMax and CPUQuota cannot be negative")
+	}
+
+	configArgs["MemEnabled"] = res.MemoryMax != 0
+	configArgs["CPUEnabled"] = res.CPUQuota != 0
+
+	if res.MemoryMax != 0 {
+		configArgs["MemoryMax"] = fmt.Sprintf("%v%s", res.MemoryMax, "M")
+	}
+	if res.CPUQuota != 0 {
+		configArgs["CPUQuota"] = fmt.Sprintf("%v%s", res.CPUQuota, "%")
+	}
+
+	if !slices.Contains(OOMPolicy, strings.ToLower(res.OOMPolicy)) {
+		return fmt.Errorf("Invalid OOMPolicy: %s", res.OOMPolicy)
+	}
+
+	configArgs["OOMPolicy"] = strings.ToLower(res.OOMPolicy)
+
+	return nil
 }

--- a/pkg/onboard/templates/systemdTemplates/discover.service
+++ b/pkg/onboard/templates/systemdTemplates/discover.service
@@ -17,18 +17,14 @@ StandardError=file:/opt/accuknox-discover/accuknox-discover-err.log
 Restart=always
 RestartSec=10
 
-CPUQuota={{ .CPUQuota | default "5%" }}
-MemoryMax={{ .MemoryMax | default "100M" }}
-
-{{- if gt .SystemdVersion 241 }}
-MemoryHigh={{ .MemoryHigh | default "80M" }}
+{{- if .CPUEnabled }}
+CPUQuota={{ .CPUQuota | default "10%" }}
 {{- end }}
 
-{{- if gt .SystemdVersion 241 }}
-CPUWeight=50
+{{- if .MemEnabled }}
+MemoryMax={{ .MemoryMax | default "250M" }}
+OOMPolicy={{ .OOMPolicy | default "stop" }}
 {{- end }}
-
-OOMPolicy=kill
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/onboard/templates/systemdTemplates/feeder-service.service
+++ b/pkg/onboard/templates/systemdTemplates/feeder-service.service
@@ -24,18 +24,14 @@ ExecStart=/opt/accuknox-feeder-service/accuknox-feeder-service
 Restart=always
 RestartSec=10
 
-CPUQuota={{ .CPUQuota | default "5%" }}
-MemoryMax={{ .MemoryMax | default "100M" }}
-
-{{- if gt .SystemdVersion 241 }}
-MemoryHigh={{ .MemoryHigh | default "80M" }}
+{{- if .CPUEnabled }}
+CPUQuota={{ .CPUQuota | default "10%" }}
 {{- end }}
 
-{{- if gt .SystemdVersion 241 }}
-CPUWeight=50
+{{- if .MemEnabled }}
+MemoryMax={{ .MemoryMax | default "250M" }}
+OOMPolicy={{ .OOMPolicy | default "stop" }}
 {{- end }}
-
-OOMPolicy=kill
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/onboard/templates/systemdTemplates/hardening-agent.service
+++ b/pkg/onboard/templates/systemdTemplates/hardening-agent.service
@@ -17,18 +17,14 @@ StandardError=file:/opt/accuknox-hardening-agent/accuknox-hardening-agent-err.lo
 Restart=always
 RestartSec=10
 
-CPUQuota={{ .CPUQuota | default "5%" }}
-MemoryMax={{ .MemoryMax | default "100M" }}
-
-{{- if gt .SystemdVersion 241 }}
-MemoryHigh={{ .MemoryHigh | default "80M" }}
+{{- if .CPUEnabled }}
+CPUQuota={{ .CPUQuota | default "10%" }}
 {{- end }}
 
-{{- if gt .SystemdVersion 241 }}
-CPUWeight=50
+{{- if .MemEnabled }}
+MemoryMax={{ .MemoryMax | default "250M" }}
+OOMPolicy={{ .OOMPolicy | default "stop" }}
 {{- end }}
-
-OOMPolicy=kill
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/onboard/templates/systemdTemplates/kubearmor.service
+++ b/pkg/onboard/templates/systemdTemplates/kubearmor.service
@@ -16,18 +16,14 @@ StandardError=file:/opt/kubearmor/kubearmor-err.log
 Restart=always
 RestartSec=10
 
-CPUQuota={{ .CPUQuota | default "5%" }}
-MemoryMax={{ .MemoryMax | default "300M" }}
-
-{{- if gt .SystemdVersion 241 }}
-MemoryHigh={{ .MemoryHigh | default "250M" }}
+{{- if .CPUEnabled }}
+CPUQuota={{ .CPUQuota | default "25%" }}
 {{- end }}
 
-{{- if gt .SystemdVersion 241 }}
-CPUWeight=50
+{{- if .MemEnabled }}
+MemoryMax={{ .MemoryMax | default "600M" }}
+OOMPolicy={{ .OOMPolicy | default "stop" }}
 {{- end }}
-
-OOMPolicy=kill
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/onboard/templates/systemdTemplates/pea.service
+++ b/pkg/onboard/templates/systemdTemplates/pea.service
@@ -23,19 +23,14 @@ StandardError=file:/opt/accuknox-policy-enforcement-agent/accuknox-policy-enforc
 Restart=always
 RestartSec=10
 
-
-CPUQuota={{ .CPUQuota | default "5%" }}
-MemoryMax={{ .MemoryMax | default "100M" }}
-
-{{- if gt .SystemdVersion 241 }}
-MemoryHigh={{ .MemoryHigh | default "80M" }}
+{{- if .CPUEnabled }}
+CPUQuota={{ .CPUQuota | default "10%" }}
 {{- end }}
 
-{{- if gt .SystemdVersion 241 }}
-CPUWeight=50
+{{- if .MemEnabled }}
+MemoryMax={{ .MemoryMax | default "250M" }}
+OOMPolicy={{ .OOMPolicy | default "stop" }}
 {{- end }}
-
-OOMPolicy=kill
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/onboard/templates/systemdTemplates/relay-server.service
+++ b/pkg/onboard/templates/systemdTemplates/relay-server.service
@@ -17,18 +17,14 @@ StandardError=file:/opt/kubearmor-relay-server/kubearmor-relay-server-err.log
 Restart=always
 RestartSec=10
 
-CPUQuota={{ .CPUQuota | default "5%" }}
-MemoryMax={{ .MemoryMax | default "100M" }}
-
-{{- if gt .SystemdVersion 241 }}
-MemoryHigh={{ .MemoryHigh | default "80M" }}
+{{- if .CPUEnabled }}
+CPUQuota={{ .CPUQuota | default "10%" }}
 {{- end }}
 
-{{- if gt .SystemdVersion 241 }}
-CPUWeight=50
+{{- if .MemEnabled }}
+MemoryMax={{ .MemoryMax | default "250M" }}
+OOMPolicy={{ .OOMPolicy | default "stop" }}
 {{- end }}
-
-OOMPolicy=kill
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/onboard/templates/systemdTemplates/sia.service
+++ b/pkg/onboard/templates/systemdTemplates/sia.service
@@ -23,18 +23,14 @@ StandardError=file:/opt/accuknox-shared-informer-agent/accuknox-shared-informer-
 Restart=always
 RestartSec=10
 
-CPUQuota={{ .CPUQuota | default "5%" }}
-MemoryMax={{ .MemoryMax | default "100M" }}
-
-{{- if gt .SystemdVersion 241 }}
-MemoryHigh={{ .MemoryHigh | default "80M" }}
+{{- if .CPUEnabled }}
+CPUQuota={{ .CPUQuota | default "10%" }}
 {{- end }}
 
-{{- if gt .SystemdVersion 241 }}
-CPUWeight=50
+{{- if .MemEnabled }}
+MemoryMax={{ .MemoryMax | default "250M" }}
+OOMPolicy={{ .OOMPolicy | default "stop" }}
 {{- end }}
-
-OOMPolicy=kill
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/onboard/templates/systemdTemplates/spire-agent.service
+++ b/pkg/onboard/templates/systemdTemplates/spire-agent.service
@@ -19,18 +19,14 @@ StandardError=file:/opt/spire-agent/spire-agent-err.log
 Restart=always
 RestartSec=10
 
-CPUQuota={{ .CPUQuota | default "5%" }}
-MemoryMax={{ .MemoryMax | default "100M" }}
-
-{{- if gt .SystemdVersion 241 }}
-MemoryHigh={{ .MemoryHigh | default "80M" }}
+{{- if .CPUEnabled }}
+CPUQuota={{ .CPUQuota | default "10%" }}
 {{- end }}
 
-{{- if gt .SystemdVersion 241 }}
-CPUWeight=50
+{{- if .MemEnabled }}
+MemoryMax={{ .MemoryMax | default "250M" }}
+OOMPolicy={{ .OOMPolicy | default "stop" }}
 {{- end }}
-
-OOMPolicy=kill
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/onboard/templates/systemdTemplates/sumengine.service
+++ b/pkg/onboard/templates/systemdTemplates/sumengine.service
@@ -29,18 +29,14 @@ StandardError=file:/opt/accuknox-sumengine/accuknox-sumengine-err.log
 Restart=always
 RestartSec=10
 
-CPUQuota={{ .CPUQuota | default "5%" }}
-MemoryMax={{ .MemoryMax | default "100M" }}
-
-{{- if gt .SystemdVersion 241 }}
-MemoryHigh={{ .MemoryHigh | default "80M" }}
+{{- if .CPUEnabled }}
+CPUQuota={{ .CPUQuota | default "10%" }}
 {{- end }}
 
-{{- if gt .SystemdVersion 241 }}
-CPUWeight=50
+{{- if .MemEnabled }}
+MemoryMax={{ .MemoryMax | default "250M" }}
+OOMPolicy={{ .OOMPolicy | default "stop" }}
 {{- end }}
-
-OOMPolicy=kill
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/onboard/templates/systemdTemplates/vm-adapter.service
+++ b/pkg/onboard/templates/systemdTemplates/vm-adapter.service
@@ -25,18 +25,14 @@ StandardError=file:/opt/kubearmor-vm-adapter/kubearmor-vm-adapter-err.log
 Restart=always
 RestartSec=10
 
-CPUQuota={{ .CPUQuota | default "5%" }}
-MemoryMax={{ .MemoryMax | default "100M" }}
-
-{{- if gt .SystemdVersion 241 }}
-MemoryHigh={{ .MemoryHigh | default "80M" }}
+{{- if .CPUEnabled }}
+CPUQuota={{ .CPUQuota | default "10%" }}
 {{- end }}
 
-{{- if gt .SystemdVersion 241 }}
-CPUWeight=50
+{{- if .MemEnabled }}
+MemoryMax={{ .MemoryMax | default "250M" }}
+OOMPolicy={{ .OOMPolicy | default "stop" }}
 {{- end }}
-
-OOMPolicy=kill
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/onboard/types.go
+++ b/pkg/onboard/types.go
@@ -28,6 +28,8 @@ var (
 		ClusterType_VM:  "vm",
 		ClusterType_ECS: "ecs",
 	}
+
+	OOMPolicy = []string{"continue", "stop", "kill"}
 )
 
 type NodeType string
@@ -459,7 +461,9 @@ type SplunkConfig struct {
 }
 
 type ResourceConfig struct {
+	MemEnabled bool
+	CPUEnabled bool
 	CPUQuota   int64
 	MemoryMax  int64
-	MemoryHigh int64
+	OOMPolicy  string
 }


### PR DESCRIPTION
This PR contains the following changes:
- set memory and cpu constraints for kubearmor and agents only if user explicitly mentions the data

flags to use 
```
--kubearmor.memory-max 250  // will set the MaxMemory param in systemd to 250M
--kubearmor.cpu-quota 25  // will set the CPU quota for kubearmor to 25%
--kubearmor.oom-policy stop // set kubearmor OOMPolicy to stop 

--agents.memory-max 150 // set agents max memory to 150M
--agents.cpu-quota 10 // set agents cpu quota to 10%
--agents.oom-policy stop // set agents OOMPolicy to stop 

```