### PR TITLE
fix(onboard): handle `deactivating` service state

### DIFF
--- a/pkg/onboard/systemdUtils.go
+++ b/pkg/onboard/systemdUtils.go
@@ -667,8 +667,11 @@ func StopSystemdService(serviceName string, skipDeleteDisable, force bool) error
 		return fmt.Errorf("Failed to check service status: %s", err.Error())
 	}
 
-	// service not active, return
-	if property.Value.Value() != "active" && !force {
+	state, ok := property.Value.Value().(string)
+	if !ok {
+		return fmt.Errorf("failed to get %s service state", serviceName)
+	}
+	if state != "active" && state != "deactivating" && !force {
 		return nil
 	}
 


### PR DESCRIPTION
Previously, if any systemd service was in the "deactivating" state, knoxctl did not attempt to stop it and instead tried to overwrite the binary with the newly downloaded one, resulting in a "text file busy" error.

Example,
```
Installation failed!! Error: open /opt/kubearmor-vm-adapter/kubearmor-vm-adapter: text file busy.
```
