### PR TITLE
fix: error looking up logging plugin <no value> while onboard rra

### DIFF
--- a/pkg/onboard/scanner.go
+++ b/pkg/onboard/scanner.go
@@ -62,6 +62,11 @@ func (cc *ClusterConfig) InitRRAConfig(authToken, url, tenantID, clusterID, clus
 	cc.RRAConfigObject.Profile = profile
 	cc.RRAConfigObject.Benchmark = benchmark
 
+	// docker config
+	cc.RRAConfigObject.DockerLogDriver = GetDockerLogDriver()
+	cc.RRAConfigObject.DockerLogRotateMaxSize = cc.LogRotateMaxSize
+	cc.RRAConfigObject.DockerLogRotateMaxFile = fmt.Sprintf("%d", cc.LogRotateMaxFile)
+
 	switch cc.Mode {
 	case VMMode_Docker:
 		cc.RRAImage, err = getImage(registry, cm.DefaultDockerRegistry,

--- a/pkg/onboard/types.go
+++ b/pkg/onboard/types.go
@@ -440,6 +440,11 @@ type RRAConfig struct {
 	// Spire configs
 	SpireSecretDir string
 	GatewayServer  string
+
+	// docker logging
+	DockerLogDriver        string
+	DockerLogRotateMaxSize string
+	DockerLogRotateMaxFile string
 }
 
 var ErrInvalidToken = errors.New("invalid JWT format")


### PR DESCRIPTION
This PR fixes 
``` 
⠋ Container accuknox-rra  Creating                                                                                                     
Error response from daemon: error looking up logging plugin <no value>: plugin "<no value>" not found
``` 
while onboard RRA in docker mode