### PR TITLE
fix(systemd): stop restarting agents after burst

### DIFF
--- a/cmd/vm-agent-reset.go
+++ b/cmd/vm-agent-reset.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"github.com/accuknox/accuknox-cli-v2/pkg/vm"
+	"github.com/spf13/cobra"
+)
+
+var exclude []string
+
+var restCmd = &cobra.Command{
+	Use:   "agent-reset",
+	Short: "Command for resetting restart counter for all agents",
+	Long:  "Command for resetting restart counter for all agents",
+	RunE: func(cmd *cobra.Command, args []string) error {
+
+		return vm.Reset(exclude)
+	},
+}
+
+func init() {
+	vmCmd.AddCommand(restCmd)
+	restCmd.PersistentFlags().StringSliceVar(&exclude, "exclude", []string{}, "agents that doesn't need restart counter reset")
+
+}

--- a/pkg/onboard/cpNodeSD.go
+++ b/pkg/onboard/cpNodeSD.go
@@ -132,7 +132,7 @@ func (ic *InitConfig) InitializeControlPlaneSD() error {
 	// download and extract systemd packages
 	err = ic.SystemdInstall()
 	if err != nil {
-		logger.Error("Installation failed!! Cleaning up downloaded assets...")
+		logger.Error("Installation failed!! Cleaning up downloaded assets...\n%v\n", err)
 		// ignoring G104 - can't send nil in installation failed case
 		Deletedir(cm.DownloadDir)
 		DeboardSystemd(NodeType_ControlPlane) // #nosec G104

--- a/pkg/onboard/systemdUtils.go
+++ b/pkg/onboard/systemdUtils.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/Masterminds/sprig"
 	cm "github.com/accuknox/accuknox-cli-v2/pkg/common"
@@ -740,7 +741,7 @@ func StartSystemdService(serviceName string) error {
 	}
 
 	// Start the service
-	ch := make(chan string)
+	ch := make(chan string, 1)
 	if _, err := conn.RestartUnitContext(ctx, serviceName, "replace", ch); err != nil {
 		return fmt.Errorf("failed to start %s: %v", serviceName, err)
 	}
@@ -757,7 +758,7 @@ func StopSystemdService(serviceName string, skipDeleteDisable, force bool) error
 	}
 	defer conn.Close()
 
-	stopChan := make(chan string)
+	stopChan := make(chan string, 1)
 
 	property, err := conn.GetUnitPropertyContext(ctx, serviceName, "ActiveState")
 	if err != nil {
@@ -826,10 +827,10 @@ func DeboardSystemd(nodeType NodeType) error {
 		if obj.ServiceName == "" {
 			continue
 		}
-		err := StopSystemdService(obj.ServiceName, false, true)
+		err := StopSystemdService(obj.ServiceName, true, true)
 		if err != nil {
 			logger.Error("error stopping %s: %s", obj.ServiceName, err)
-			return err
+			continue
 		}
 
 		Deletedir(obj.AgentDir)
@@ -1108,4 +1109,61 @@ func GetSystemdServiceStatus(name string) (string, error) {
 	}
 
 	return status, nil
+}
+
+func ResetRestartCount(exclude map[string]bool) error {
+	pseudoCC := new(ClusterConfig)
+	pseudoCC.CreateSystemdServiceObjects()
+
+	for _, obj := range pseudoCC.SystemdServiceObjects {
+		if obj.ServiceName == "" || exclude[obj.ServiceName] {
+			continue
+		}
+		if err := ResetRestartCounter(obj.ServiceName); err != nil {
+			fmt.Printf("failed to reset restart counter for %v : %v\n", obj.ServiceName, err)
+		}
+	}
+
+	return nil
+}
+
+func ResetRestartCounter(service string) error {
+	if service == "" {
+		return nil
+	}
+	ctx := context.Background()
+
+	dConn, err := dbus.NewWithContext(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to connect to systemd: %v", err)
+	}
+	defer dConn.Close()
+
+	err = dConn.ResetFailedUnitContext(ctx, service)
+	if err != nil {
+		fmt.Printf("failed to reset restart counter for %s: %v\n", service, err)
+		return nil
+	}
+
+	err = dConn.ReloadContext(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to reload systemd configuration: %v", err)
+	}
+
+	ch := make(chan string, 1)
+	_, err = dConn.StartUnitContext(ctx, service, "replace", ch)
+	if err != nil {
+		return fmt.Errorf("failed to start %s: %v", service, err)
+	}
+
+	select {
+	case msg := <-ch:
+		if msg != "done" {
+			return fmt.Errorf("failed to start %s: %v", service, err)
+		}
+	case <-time.After(20 * time.Second):
+		return fmt.Errorf("timeout waiting for %s to start", service)
+	}
+
+	return nil
 }

--- a/pkg/onboard/templates/systemdTemplates/containerscan.service
+++ b/pkg/onboard/templates/systemdTemplates/containerscan.service
@@ -25,7 +25,13 @@ StandardError=file:/opt/{{.AgentName}}/{{.AgentName}}-err.log
 {{- end }}
 
 CPUQuota={{ .CPUQuota | default "5%" }}
+{{- if gt .SystemdVersion 229 }}
 MemoryMax={{ .MemoryMax | default "100M" }}
+{{- end }}
+
+{{- if lt .SystemdVersion 230 }} 
+MemoryLimit={{ .MemoryMax | default "100M" }}
+{{- end }}
 
 {{- if gt .SystemdVersion 241 }}
 MemoryHigh={{ .MemoryHigh | default "80M" }}

--- a/pkg/onboard/templates/systemdTemplates/discover.service
+++ b/pkg/onboard/templates/systemdTemplates/discover.service
@@ -32,7 +32,14 @@ Restart=always
 RestartSec=10
 
 CPUQuota={{ .CPUQuota | default "5%" }}
+{{- if gt .SystemdVersion 229 }}
 MemoryMax={{ .MemoryMax | default "100M" }}
+{{- end }}
+
+{{- if lt .SystemdVersion 230 }} 
+MemoryLimit={{ .MemoryMax | default "100M" }}
+{{- end }}
+
 
 {{- if gt .SystemdVersion 241 }}
 MemoryHigh={{ .MemoryHigh | default "80M" }}

--- a/pkg/onboard/templates/systemdTemplates/discover.service
+++ b/pkg/onboard/templates/systemdTemplates/discover.service
@@ -2,6 +2,20 @@
 Description=accuknox-discover
 After=sumengine.service
 
+{{- if ge .SystemdVersion 230 }}
+# limit to 4 restarts in 60 seconds
+# for newer systemd versions
+# https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#StartLimitIntervalSec=interval
+StartLimitIntervalSec=90
+StartLimitBurst=3
+{{- else if ge .SystemdVersion 220 }}
+# limit to 4 restarts in 60 seconds
+# for newer systemd versions
+# https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#StartLimitIntervalSec=interval
+StartLimitInterval=90
+StartLimitBurst=3
+{{- end }}
+
 [Service]
 User=root
 KillMode=control-group
@@ -28,7 +42,17 @@ MemoryHigh={{ .MemoryHigh | default "80M" }}
 CPUWeight=50
 {{- end }}
 
-OOMPolicy=kill
+{{- if ge .SystemdVersion 240 }}
+OOMPolicy=stop
+{{- end }}
+
+{{- if lt .SystemdVersion 220 }}
+# limit to 4 restarts in 60 seconds 
+# for older systemd versions
+# https://www.freedesktop.org/software/systemd/man/systemd.service.html
+StartLimitInterval=90
+StartLimitBurst=3
+{{- end }}
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/onboard/templates/systemdTemplates/feeder-service.service
+++ b/pkg/onboard/templates/systemdTemplates/feeder-service.service
@@ -39,7 +39,13 @@ Restart=always
 RestartSec=10
 
 CPUQuota={{ .CPUQuota | default "5%" }}
+{{- if gt .SystemdVersion 229 }}
 MemoryMax={{ .MemoryMax | default "100M" }}
+{{- end }}
+
+{{- if lt .SystemdVersion 230 }} 
+MemoryLimit={{ .MemoryMax | default "100M" }}
+{{- end }}
 
 {{- if gt .SystemdVersion 241 }}
 MemoryHigh={{ .MemoryHigh | default "80M" }}

--- a/pkg/onboard/templates/systemdTemplates/feeder-service.service
+++ b/pkg/onboard/templates/systemdTemplates/feeder-service.service
@@ -2,6 +2,20 @@
 Description=accuknox-feeder-service
 After=kubearmor-vm-adapter.service kubearmor-relay.service spire-agent.service
 
+{{- if ge .SystemdVersion 230 }}
+# limit to 4 restarts in 60 seconds
+# for newer systemd versions
+# https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#StartLimitIntervalSec=interval
+StartLimitIntervalSec=90
+StartLimitBurst=3
+{{- else if ge .SystemdVersion 220 }}
+# limit to 4 restarts in 60 seconds
+# for newer systemd versions
+# https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#StartLimitIntervalSec=interval
+StartLimitInterval=90
+StartLimitBurst=3
+{{- end }}
+
 [Service]
 User=root
 KillMode=control-group
@@ -35,7 +49,18 @@ MemoryHigh={{ .MemoryHigh | default "80M" }}
 CPUWeight=50
 {{- end }}
 
-OOMPolicy=kill
+{{- if ge .SystemdVersion 240 }}
+OOMPolicy=stop
+{{- end }}
+
+
+{{- if lt .SystemdVersion 220 }}
+# limit to 4 restarts in 60 seconds 
+# for older systemd versions
+# https://www.freedesktop.org/software/systemd/man/systemd.service.html
+StartLimitInterval=90
+StartLimitBurst=3
+{{- end }}
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/onboard/templates/systemdTemplates/hardening-agent.service
+++ b/pkg/onboard/templates/systemdTemplates/hardening-agent.service
@@ -2,6 +2,20 @@
 Description=accuknox-hardening-agent
 After=kubearmor-relay.service kubearmor-vm-adapter.service
 
+{{- if ge .SystemdVersion 230 }}
+# limit to 4 restarts in 60 seconds
+# for newer systemd versions
+# https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#StartLimitIntervalSec=interval
+StartLimitIntervalSec=90
+StartLimitBurst=3
+{{- else if ge .SystemdVersion 220 }}
+# limit to 4 restarts in 60 seconds
+# for newer systemd versions
+# https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#StartLimitIntervalSec=interval
+StartLimitInterval=90
+StartLimitBurst=3
+{{- end }}
+
 [Service]
 User=root
 KillMode=control-group
@@ -28,7 +42,18 @@ MemoryHigh={{ .MemoryHigh | default "80M" }}
 CPUWeight=50
 {{- end }}
 
-OOMPolicy=kill
+{{- if ge .SystemdVersion 240 }}
+OOMPolicy=stop
+{{- end }}
+
+
+{{- if lt .SystemdVersion 220 }}
+# limit to 4 restarts in 60 seconds 
+# for older systemd versions
+# https://www.freedesktop.org/software/systemd/man/systemd.service.html
+StartLimitInterval=90
+StartLimitBurst=3
+{{- end }}
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/onboard/templates/systemdTemplates/hardening-agent.service
+++ b/pkg/onboard/templates/systemdTemplates/hardening-agent.service
@@ -32,7 +32,13 @@ Restart=always
 RestartSec=10
 
 CPUQuota={{ .CPUQuota | default "5%" }}
+{{- if gt .SystemdVersion 229 }}
 MemoryMax={{ .MemoryMax | default "100M" }}
+{{- end }}
+
+{{- if lt .SystemdVersion 230 }} 
+MemoryLimit={{ .MemoryMax | default "100M" }}
+{{- end }}
 
 {{- if gt .SystemdVersion 241 }}
 MemoryHigh={{ .MemoryHigh | default "80M" }}

--- a/pkg/onboard/templates/systemdTemplates/kubearmor.service
+++ b/pkg/onboard/templates/systemdTemplates/kubearmor.service
@@ -27,7 +27,9 @@ MemoryHigh={{ .MemoryHigh | default "250M" }}
 CPUWeight=50
 {{- end }}
 
-OOMPolicy=kill
+{{- if ge .SystemdVersion 240 }}
+OOMPolicy=stop
+{{- end }}
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/onboard/templates/systemdTemplates/pea.service
+++ b/pkg/onboard/templates/systemdTemplates/pea.service
@@ -2,6 +2,20 @@
 Description=accuknox-policy-enforcement-agent
 After=kubearmor.service kubearmor-vm-adapter.service spire-agent.service
 
+{{- if ge .SystemdVersion 230 }}
+# limit to 4 restarts in 60 seconds
+# for newer systemd versions
+# https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#StartLimitIntervalSec=interval
+StartLimitIntervalSec=90
+StartLimitBurst=3
+{{- else if ge .SystemdVersion 220 }}
+# limit to 4 restarts in 60 seconds
+# for newer systemd versions
+# https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#StartLimitIntervalSec=interval
+StartLimitInterval=90
+StartLimitBurst=3
+{{- end }}
+
 [Service]
 User=root
 KillMode=control-group
@@ -35,7 +49,17 @@ MemoryHigh={{ .MemoryHigh | default "80M" }}
 CPUWeight=50
 {{- end }}
 
-OOMPolicy=kill
+{{- if ge .SystemdVersion 240 }}
+OOMPolicy=stop
+{{- end }}
+
+{{- if lt .SystemdVersion 220 }}
+# limit to 4 restarts in 60 seconds 
+# for older systemd versions
+# https://www.freedesktop.org/software/systemd/man/systemd.service.html
+StartLimitInterval=90
+StartLimitBurst=3
+{{- end }}
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/onboard/templates/systemdTemplates/pea.service
+++ b/pkg/onboard/templates/systemdTemplates/pea.service
@@ -39,7 +39,13 @@ RestartSec=10
 
 
 CPUQuota={{ .CPUQuota | default "5%" }}
+{{- if gt .SystemdVersion 229 }}
 MemoryMax={{ .MemoryMax | default "100M" }}
+{{- end }}
+
+{{- if lt .SystemdVersion 230 }} 
+MemoryLimit={{ .MemoryMax | default "100M" }}
+{{- end }}
 
 {{- if gt .SystemdVersion 241 }}
 MemoryHigh={{ .MemoryHigh | default "80M" }}

--- a/pkg/onboard/templates/systemdTemplates/relay-server.service
+++ b/pkg/onboard/templates/systemdTemplates/relay-server.service
@@ -18,7 +18,13 @@ Restart=always
 RestartSec=10
 
 CPUQuota={{ .CPUQuota | default "5%" }}
+{{- if gt .SystemdVersion 229 }}
 MemoryMax={{ .MemoryMax | default "100M" }}
+{{- end }}
+
+{{- if lt .SystemdVersion 230 }} 
+MemoryLimit={{ .MemoryMax | default "100M" }}
+{{- end }}
 
 {{- if gt .SystemdVersion 241 }}
 MemoryHigh={{ .MemoryHigh | default "80M" }}

--- a/pkg/onboard/templates/systemdTemplates/relay-server.service
+++ b/pkg/onboard/templates/systemdTemplates/relay-server.service
@@ -28,7 +28,9 @@ MemoryHigh={{ .MemoryHigh | default "80M" }}
 CPUWeight=50
 {{- end }}
 
-OOMPolicy=kill
+{{- if ge .SystemdVersion 240 }}
+OOMPolicy=stop
+{{- end }}
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/onboard/templates/systemdTemplates/sia.service
+++ b/pkg/onboard/templates/systemdTemplates/sia.service
@@ -2,6 +2,20 @@
 Description=accuknox-shared-informer-agent
 After=kubearmor-vm-adapter.service kubearmor.service
 
+{{- if ge .SystemdVersion 230 }}
+# limit to 4 restarts in 60 seconds
+# for newer systemd versions
+# https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#StartLimitIntervalSec=interval
+StartLimitIntervalSec=90
+StartLimitBurst=3
+{{- else if ge .SystemdVersion 220 }}
+# limit to 4 restarts in 60 seconds
+# for newer systemd versions
+# https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#StartLimitIntervalSec=interval
+StartLimitInterval=90
+StartLimitBurst=3
+{{- end }}
+
 [Service]
 User=root
 KillMode=control-group
@@ -34,7 +48,18 @@ MemoryHigh={{ .MemoryHigh | default "80M" }}
 CPUWeight=50
 {{- end }}
 
-OOMPolicy=kill
+{{- if ge .SystemdVersion 240 }}
+OOMPolicy=stop
+{{- end }}
+
+{{- if lt .SystemdVersion 220 }}
+# limit to 4 restarts in 60 seconds 
+# for older systemd versions
+# https://www.freedesktop.org/software/systemd/man/systemd.service.html
+StartLimitInterval=90
+StartLimitBurst=3
+{{- end }}
+
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/onboard/templates/systemdTemplates/sia.service
+++ b/pkg/onboard/templates/systemdTemplates/sia.service
@@ -38,7 +38,13 @@ Restart=always
 RestartSec=10
 
 CPUQuota={{ .CPUQuota | default "5%" }}
+{{- if gt .SystemdVersion 229 }}
 MemoryMax={{ .MemoryMax | default "100M" }}
+{{- end }}
+
+{{- if lt .SystemdVersion 230 }} 
+MemoryLimit={{ .MemoryMax | default "100M" }}
+{{- end }}
 
 {{- if gt .SystemdVersion 241 }}
 MemoryHigh={{ .MemoryHigh | default "80M" }}

--- a/pkg/onboard/templates/systemdTemplates/spire-agent.service
+++ b/pkg/onboard/templates/systemdTemplates/spire-agent.service
@@ -34,7 +34,13 @@ Restart=always
 RestartSec=10
 
 CPUQuota={{ .CPUQuota | default "5%" }}
+{{- if gt .SystemdVersion 229 }}
 MemoryMax={{ .MemoryMax | default "100M" }}
+{{- end }}
+
+{{- if lt .SystemdVersion 230 }} 
+MemoryLimit={{ .MemoryMax | default "100M" }}
+{{- end }}
 
 {{- if gt .SystemdVersion 241 }}
 MemoryHigh={{ .MemoryHigh | default "80M" }}

--- a/pkg/onboard/templates/systemdTemplates/spire-agent.service
+++ b/pkg/onboard/templates/systemdTemplates/spire-agent.service
@@ -4,6 +4,20 @@ Description=Spire Agent
 PartOf=rra.service
 {{- end }}
 
+{{- if ge .SystemdVersion 230 }}
+# limit to 4 restarts in 60 seconds
+# for newer systemd versions
+# https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#StartLimitIntervalSec=interval
+StartLimitIntervalSec=60
+StartLimitBurst=4
+{{- else if ge .SystemdVersion 220 }}
+# limit to 4 restarts in 60 seconds
+# for newer systemd versions
+# https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#StartLimitIntervalSec=interval
+StartLimitInterval=60
+StartLimitBurst=4
+{{- end }}
+
 [Service]
 User=root
 KillMode=control-group
@@ -30,7 +44,18 @@ MemoryHigh={{ .MemoryHigh | default "80M" }}
 CPUWeight=50
 {{- end }}
 
-OOMPolicy=kill
+{{- if ge .SystemdVersion 240 }}
+OOMPolicy=stop
+{{- end }}
+
+{{- if lt .SystemdVersion 220 }}
+# limit to 4 restarts in 60 seconds 
+# for older systemd versions
+# https://www.freedesktop.org/software/systemd/man/systemd.service.html
+StartLimitInterval=60
+StartLimitBurst=4
+{{- end }}
+
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/onboard/templates/systemdTemplates/sumengine.service
+++ b/pkg/onboard/templates/systemdTemplates/sumengine.service
@@ -6,6 +6,20 @@ After=kubearmor.service
 After=kubearmor-relay.service
 {{- end }}
 
+{{- if ge .SystemdVersion 230 }}
+# limit to 4 restarts in 60 seconds
+# for newer systemd versions
+# https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#StartLimitIntervalSec=interval
+StartLimitIntervalSec=90
+StartLimitBurst=3
+{{- else if ge .SystemdVersion 220 }}
+# limit to 4 restarts in 60 seconds
+# for newer systemd versions
+# https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#StartLimitIntervalSec=interval
+StartLimitInterval=90
+StartLimitBurst=3
+{{- end }}
+
 [Service]
 User=root
 KillMode=control-group
@@ -40,7 +54,17 @@ MemoryHigh={{ .MemoryHigh | default "80M" }}
 CPUWeight=50
 {{- end }}
 
-OOMPolicy=kill
+{{- if ge .SystemdVersion 240 }}
+OOMPolicy=stop
+{{- end }}
+
+{{- if lt .SystemdVersion 220 }}
+# limit to 4 restarts in 60 seconds 
+# for older systemd versions
+# https://www.freedesktop.org/software/systemd/man/systemd.service.html
+StartLimitInterval=90
+StartLimitBurst=3
+{{- end }}
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/onboard/templates/systemdTemplates/sumengine.service
+++ b/pkg/onboard/templates/systemdTemplates/sumengine.service
@@ -44,7 +44,13 @@ Restart=always
 RestartSec=10
 
 CPUQuota={{ .CPUQuota | default "5%" }}
+{{- if gt .SystemdVersion 229 }}
 MemoryMax={{ .MemoryMax | default "100M" }}
+{{- end }}
+
+{{- if lt .SystemdVersion 230 }} 
+MemoryLimit={{ .MemoryMax | default "100M" }}
+{{- end }}
 
 {{- if gt .SystemdVersion 241 }}
 MemoryHigh={{ .MemoryHigh | default "80M" }}

--- a/pkg/onboard/templates/systemdTemplates/vm-adapter.service
+++ b/pkg/onboard/templates/systemdTemplates/vm-adapter.service
@@ -40,7 +40,13 @@ Restart=always
 RestartSec=10
 
 CPUQuota={{ .CPUQuota | default "5%" }}
+{{- if gt .SystemdVersion 229 }}
 MemoryMax={{ .MemoryMax | default "100M" }}
+{{- end }}
+
+{{- if lt .SystemdVersion 230 }} 
+MemoryLimit={{ .MemoryMax | default "100M" }}
+{{- end }}
 
 {{- if gt .SystemdVersion 241 }}
 MemoryHigh={{ .MemoryHigh | default "80M" }}

--- a/pkg/onboard/templates/systemdTemplates/vm-adapter.service
+++ b/pkg/onboard/templates/systemdTemplates/vm-adapter.service
@@ -2,6 +2,20 @@
 Description=kubearmor-vm-adapter
 After=kubearmor.service
 
+{{- if ge .SystemdVersion 230 }}
+# limit to 4 restarts in 60 seconds
+# for newer systemd versions
+# https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#StartLimitIntervalSec=interval
+StartLimitIntervalSec=90
+StartLimitBurst=3
+{{- else if ge .SystemdVersion 220 }}
+# limit to 4 restarts in 60 seconds
+# for newer systemd versions
+# https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#StartLimitIntervalSec=interval
+StartLimitInterval=90
+StartLimitBurst=3
+{{- end }}
+
 [Service]
 User=root
 KillMode=control-group
@@ -36,7 +50,17 @@ MemoryHigh={{ .MemoryHigh | default "80M" }}
 CPUWeight=50
 {{- end }}
 
-OOMPolicy=kill
+{{- if ge .SystemdVersion 240 }}
+OOMPolicy=stop
+{{- end }}
+
+{{- if lt .SystemdVersion 220 }}
+# limit to 4 restarts in 60 seconds 
+# for older systemd versions
+# https://www.freedesktop.org/software/systemd/man/systemd.service.html
+StartLimitInterval=90
+StartLimitBurst=3
+{{- end }}
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/vm/vm-agent-reset.go
+++ b/pkg/vm/vm-agent-reset.go
@@ -1,0 +1,23 @@
+package vm
+
+import (
+	"github.com/accuknox/accuknox-cli-v2/pkg/logger"
+	"github.com/accuknox/accuknox-cli-v2/pkg/onboard"
+)
+
+func Reset(exclude []string) error {
+
+	excludeMap := excludeAgents(exclude)
+
+	logger.Info1("Resetting restart counter for agents")
+
+	return onboard.ResetRestartCount(excludeMap)
+}
+
+func excludeAgents(exclude []string) map[string]bool {
+	excluded := make(map[string]bool)
+	for _, agent := range exclude {
+		excluded[agent] = true
+	}
+	return excluded
+}


### PR DESCRIPTION
JIRA: https://accu-knox.atlassian.net/browse/CNAPP-26381

This PR contains the following changes:
- return full error once onboarding fails
- update systemd files with `StartLimit` to stop agent abnormal frequent restarts 
- update MemoryMax to MemoryLimit in systemd version < 229
- new command `agent-reset` to reset the counter after max restart is reached

```
sudo ./knoxctl vm agent-reset --help
Command for resetting restart counter for all agents

Usage:
  knoxctl vm agent-reset [flags]

Flags:
      --exclude strings   agents that doesn't need restart counter reset
  -h, --help              help for agent-reset

```

Tested on :
- **CentOS 7** 
  ```
  uname -a
  Linux localhost.localdomain 3.10.0-514.el7.x86_64 #1 SMP Tue Nov 22 16:42:41 UTC 2016 x86_64 x86_64 x86_64 GNU/Linux

  hostnamectl
   Static hostname: localhost.localdomain
         Icon name: computer-vm
           Chassis: vm
        Machine ID: bf80aeb67ce945b097344e2af93265e0
           Boot ID: 96531e13040e4f98ba0f945511e9250c
    Virtualization: microsoft
  Operating System: CentOS Linux 7 (Core)
       CPE OS Name: cpe:/o:centos:centos:7
            Kernel: Linux 3.10.0-514.el7.x86_64
      Architecture: x86-64

  systemctl --version
  systemd 219
  +PAM +AUDIT +SELINUX +IMA -APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ -LZ4 -SECCOMP +BLKID +ELFUTILS +KMOD +IDN

  ```
- **Ubuntu 16**
  ```
  uname -a
  Linux ubuntu 4.4.0-186-generic #216-Ubuntu SMP Wed Jul 1 05:34:05 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux

  hostnamectl
   Static hostname: ubuntu
         Icon name: computer-vm
           Chassis: vm
        Machine ID: 50f0ce578a6a85a711b993d969dcbe02
           Boot ID: a4074fbba7d24258a1a96a0ac3f121f4
    Virtualization: microsoft
  Operating System: Ubuntu 16.04.7 LTS
            Kernel: Linux 4.4.0-186-generic
      Architecture: x86-64
  systemctl --version
  systemd 229
  +PAM +AUDIT +SELINUX +IMA +APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ -LZ4 +SECCOMP +BLKID +ELFUTILS +KMOD -IDN

  ```
- **Debian**
  ```
	uname -a           
	Linux worker 6.12.48+deb13-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.12.48-1 (2025-09-20) x86_64 GNU/Linux

	hostnamectl
	 Static hostname: worker
	       Icon name: computer-vm
	         Chassis: vm 🖴
	      Machine ID: e2d1372ce91042ad9132d0790b0c7d93
	         Boot ID: c3c0ce6aab1b4f62b35ef86c3c8e2870
	    AF_VSOCK CID: 1
	  Virtualization: microsoft
	Operating System: Debian GNU/Linux 13 (trixie)    
	          Kernel: Linux 6.12.48+deb13-amd64
	    Architecture: x86-64
	 Hardware Vendor: Microsoft Corporation
	  Hardware Model: Virtual Machine
	Firmware Version: Hyper-V UEFI Release v4.1
	   Firmware Date: Thu 2025-09-25
	    Firmware Age: 6month 2w 3d
	    
	systemctl --version
	systemd 257 (257.8-1~deb13u2)
	+PAM +AUDIT +SELINUX +APPARMOR +IMA +IPE +SMACK +SECCOMP +GCRYPT -GNUTLS +OPENSSL +ACL +BLKID +CURL +ELFUTILS +FIDO2 +IDN2 -IDN +IPTC +KMOD +LIBCRYPTSETUP +LIBCRYPTSETUP_PLUGINS +LIBFDISK +PCRE2 +PWQUALITY +P11KIT +QRENCODE +TPM2 +BZIP2 +LZ4 +XZ +ZLIB +ZSTD +BPF_FRAMEWORK +BTF -XKBCOMMON -UTMP +SYSVINIT +LIBARCHIVE

  ```