### PR TITLE
Cherry pick of #451: run kubearmor in host network

### DIFF
--- a/pkg/onboard/templates/docker-compose_cp-node.yaml
+++ b/pkg/onboard/templates/docker-compose_cp-node.yaml
@@ -34,6 +34,8 @@ services:
       accuknox-net:
         aliases:
           - spire-agent
+    extra_hosts:
+      - "kubearmor:host-gateway"
     restart: always
     ports:
       - "9091:9091"
@@ -68,6 +70,8 @@ services:
       accuknox-net:
         aliases:
           - wait-for-it
+    extra_hosts:
+      - "kubearmor:host-gateway"
 {{- end }}
   kubearmor-init:
     profiles:
@@ -93,6 +97,8 @@ services:
       accuknox-net:
         aliases:
           - kubearmor-init
+    extra_hosts:
+      - "kubearmor:host-gateway"
   {{- if eq (printf "%.3s" .DockerComposeVersion) "v1." }}
     entrypoint:
       - sh
@@ -165,13 +171,9 @@ services:
       - "/usr/share/kubearmor:/usr/share/kubearmor:rw"
       - "/var/run/kubearmor:/var/run/kubearmor:rw"
     restart: always
-    ports:
-      - "{{.KubeArmorPort}}:32767"
-    networks:
-      accuknox-net:
-        aliases:
-          - kubearmor
+    network_mode: "host"
     pid: "host"
+    stop_grace_period: 20s
     privileged: true
     logging:
       driver: {{.DockerLogDriver}}
@@ -239,6 +241,8 @@ services:
       accuknox-net:
         aliases:
           - kubearmor-relay-server
+    extra_hosts:
+      - "kubearmor:host-gateway"
     logging:
       driver: {{.DockerLogDriver}}
       options:
@@ -311,6 +315,8 @@ services:
       accuknox-net:
         aliases:
           - kubearmor-vm-adapter
+    extra_hosts:
+      - "kubearmor:host-gateway"
     logging:
       driver: {{.DockerLogDriver}}
       options:
@@ -366,6 +372,8 @@ services:
       accuknox-net:
         aliases:
           - shared-informer-agent
+    extra_hosts:
+      - "kubearmor:host-gateway"
     logging:
       driver: {{.DockerLogDriver}}
       options:
@@ -463,6 +471,8 @@ services:
       accuknox-net:
         aliases:
           - feeder-service
+    extra_hosts:
+      - "kubearmor:host-gateway"
     logging:
       driver: {{.DockerLogDriver}}
       options:
@@ -515,6 +525,8 @@ services:
       accuknox-net:
         aliases:
           - policy-enforcement-agent
+    extra_hosts:
+      - "kubearmor:host-gateway"
     logging:
       driver: {{.DockerLogDriver}}
       options:
@@ -553,6 +565,8 @@ services:
       accuknox-net:
         aliases:
           - discover
+    extra_hosts:
+      - "kubearmor:host-gateway"
     logging:
       driver: {{.DockerLogDriver}}
       options:
@@ -589,6 +603,8 @@ services:
       accuknox-net:
         aliases:
           - sumengine
+    extra_hosts:
+      - "kubearmor:host-gateway"
     logging:
       driver: {{.DockerLogDriver}}
       options:
@@ -627,6 +643,8 @@ services:
       accuknox-net:
         aliases:
           - hardening-agent
+    extra_hosts:
+      - "kubearmor:host-gateway"
     logging:
       driver: {{.DockerLogDriver}}
       options:
@@ -653,6 +671,8 @@ services:
       accuknox-net:
         aliases:
           - rabbitmq
+    extra_hosts:
+      - "kubearmor:host-gateway"
     volumes:
       - "{{.ConfigPath}}/rabbitmq/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf"
       - "{{.ConfigPath}}/rabbitmq/definitions.json:/etc/rabbitmq/definitions.json"

--- a/pkg/onboard/templates/docker-compose_node.yaml
+++ b/pkg/onboard/templates/docker-compose_node.yaml
@@ -34,6 +34,8 @@ services:
       accuknox-net:
         aliases:
           - spire-agent
+    extra_hosts:
+      - "kubearmor:host-gateway"
     restart: always
     ports:
       - "9091:9091"
@@ -68,6 +70,8 @@ services:
       accuknox-net:
         aliases:
           - wait-for-it
+    extra_hosts:
+      - "kubearmor:host-gateway"
   {{- end }}
   kubearmor-init:
     profiles:
@@ -94,6 +98,8 @@ services:
       accuknox-net:
         aliases:
           - kubearmor-init
+    extra_hosts:
+      - "kubearmor:host-gateway"
   {{- if eq (printf "%.3s" .DockerComposeVersion) "v1." }}
     entrypoint:
       - sh
@@ -164,13 +170,9 @@ services:
       - "/usr/share/kubearmor:/usr/share/kubearmor:rw"
       - "/var/run/kubearmor:/var/run/kubearmor:rw"
     restart: always
-    ports:
-      - "{{.KubeArmorPort}}:32767"
-    networks:
-      accuknox-net:
-        aliases:
-          - kubearmor
+    network_mode: "host"
     pid: "host"
+    stop_grace_period: 20s
     privileged: true
     logging:
       driver: {{.DockerLogDriver}}


### PR DESCRIPTION
When deployed in docker mode, KubeArmor is not able to create nftables rules of network policy enforcer on the host since it is running in a bridged network. This PR updates the docker compose to run KubeArmor in host network so it can interact with host nftables.
Also increases stop grace period so cleanup can be successful on deboarding cluster.

Cherry pick of #451 to v0.9