### PR TITLE
feat(policy): add config to pea and vma for saas reconcile

### DIFF
--- a/cmd/onboard-vm-cp-node.go
+++ b/cmd/onboard-vm-cp-node.go
@@ -177,6 +177,9 @@ var cpNodeCmd = &cobra.Command{
 			return err
 		}
 
+		onboardConfig.TCArgs.PoliciesListRefresh = policiesListRefreshTime
+		onboardConfig.TCArgs.EnablePoliciesList = policiesListEnabled
+
 		switch vmMode {
 
 		case onboard.VMMode_Systemd:

--- a/cmd/onboard-vm-node.go
+++ b/cmd/onboard-vm-node.go
@@ -26,6 +26,9 @@ var (
 	// spire config - to use spire and spire cert for tls
 	spireEnabled bool
 	spireCert    bool
+
+	policiesListRefreshTime time.Duration
+	policiesListEnabled     bool
 )
 
 // joinNodeCmd represents the join command
@@ -176,6 +179,9 @@ var joinNodeCmd = &cobra.Command{
 			logger.Error("failed to create VM config: %s", err.Error())
 			return err
 		}
+
+		joinConfig.TCArgs.PoliciesListRefresh = policiesListRefreshTime
+		joinConfig.TCArgs.EnablePoliciesList = policiesListEnabled
 
 		switch vmMode {
 

--- a/cmd/onboard-vm.go
+++ b/cmd/onboard-vm.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"time"
+
 	"github.com/accuknox/accuknox-cli-v2/pkg/onboard"
 	"github.com/spf13/cobra"
 )
@@ -242,6 +244,9 @@ func init() {
 	onboardVMCmd.PersistentFlags().BoolVar(&tls.RMQEnabled, "rmq", false, "enable rabbitmq based connection instead of gRPC")
 
 	onboardVMCmd.PersistentFlags().BoolVar(&forceRecreate, "force-recreate", false, "force recreate docker containers when re-onboarding")
+
+	onboardVMCmd.PersistentFlags().BoolVar(&policiesListEnabled, "enable-policies-list", true, "enable policies list")
+	onboardVMCmd.PersistentFlags().DurationVar(&policiesListRefreshTime, "policies-list-refresh-time", 5*time.Minute, "policies list refresh time")
 
 	onboardCmd.AddCommand(onboardVMCmd)
 }

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -196,27 +196,29 @@ var (
 )
 
 const (
-	KmuxStateEventFileName = "state-kmux-config.yaml"
-	KmuxAlertsFileName     = "alerts-kmux-config.yaml"
-	KmuxLogsFileName       = "logs-kmux-config.yaml"
-	KmuxPoliciesFileName   = "policies-kmux-config.yaml"
-	KmuxSummaryFileName    = "summary-kmux-config.yaml"
-	KmuxPolicyFileName     = "policy-kmux-config.yaml"
-	KmuxSinkStream         = "publisher"
-	KmuxSourceStream       = "consumer"
-	KmuxAnnotationFileName = "annotation-kmux-config.yaml"
+	KmuxStateEventFileName   = "state-kmux-config.yaml"
+	KmuxAlertsFileName       = "alerts-kmux-config.yaml"
+	KmuxLogsFileName         = "logs-kmux-config.yaml"
+	KmuxPoliciesFileName     = "policies-kmux-config.yaml"
+	KmuxSummaryFileName      = "summary-kmux-config.yaml"
+	KmuxPolicyFileName       = "policy-kmux-config.yaml"
+	KmuxSinkStream           = "publisher"
+	KmuxSourceStream         = "consumer"
+	KmuxAnnotationFileName   = "annotation-kmux-config.yaml"
+	KmuxPoliciesListFileName = "policies-list-kmux-config.yaml"
 
 	MaxQueueLength = 255
 )
 
 var QueueName = map[string]string{
-	KmuxStateEventFileName: "state-event",
-	KmuxAlertsFileName:     "alerts",
-	KmuxLogsFileName:       "logs",
-	KmuxPoliciesFileName:   "policies",
-	KmuxSummaryFileName:    "summary-v2",
-	KmuxPolicyFileName:     "policy-v1",
-	KmuxAnnotationFileName: "annotation",
+	KmuxStateEventFileName:   "state-event",
+	KmuxAlertsFileName:       "alerts",
+	KmuxLogsFileName:         "logs",
+	KmuxPoliciesFileName:     "policies",
+	KmuxSummaryFileName:      "summary-v2",
+	KmuxPolicyFileName:       "policy-v1",
+	KmuxAnnotationFileName:   "annotation",
+	KmuxPoliciesListFileName: "policies-list",
 }
 
 var QueueDurability = map[string]bool{

--- a/pkg/onboard/cpNode.go
+++ b/pkg/onboard/cpNode.go
@@ -358,6 +358,7 @@ func (ic *InitConfig) populateCommonArgs() {
 	ic.TCArgs.SummaryKmuxConfig = common.KmuxSummaryFileName
 	ic.TCArgs.PolicyKmuxConfig = common.KmuxPolicyFileName
 	ic.TCArgs.AnnotationKmuxConfig = common.KmuxAnnotationFileName
+	ic.TCArgs.PoliciesListKmuxConfig = common.KmuxPoliciesListFileName
 
 	ic.TCArgs.DiscoverRules = combineVisibilities(ic.Visibility, ic.HostVisibility)
 
@@ -369,6 +370,7 @@ func (ic *InitConfig) populateCommonArgs() {
 	ic.TCArgs.PolicyV1Topic = getTopicName(ic.RMQTopicPrefix, "policy-v1")
 	ic.TCArgs.SummaryV2Topic = getTopicName(ic.RMQTopicPrefix, "summary-v2")
 	ic.TCArgs.AnnotationTopic = getTopicName(ic.RMQTopicPrefix, "annotation")
+	ic.TCArgs.PoliciesListKmuxConfig = getTopicName(ic.RMQTopicPrefix, "policies-list")
 
 	ic.TCArgs.SplunkConfigObject = ic.Splunk
 }
@@ -381,6 +383,7 @@ func populateAgentArgs(tcArgs *TemplateConfigArgs, configDir string) {
 	tcArgs.SummaryKmuxConfig = fmt.Sprintf("%s/%s/%s", common.InContainerConfigDir, configDir, common.KmuxSummaryFileName)
 	tcArgs.PolicyKmuxConfig = fmt.Sprintf("%s/%s/%s", common.InContainerConfigDir, configDir, common.KmuxPolicyFileName)
 	tcArgs.AnnotationKmuxConfig = fmt.Sprintf("%s/%s/%s", common.InContainerConfigDir, configDir, common.KmuxAnnotationFileName)
+	tcArgs.PoliciesListKmuxConfig = fmt.Sprintf("%s/%s/%s", common.InContainerConfigDir, configDir, common.KmuxPoliciesListFileName)
 }
 
 func populateKmuxArgs(kmuxConfigArgs *KmuxConfigTemplateArgs, agentName, kmuxFile, prefix, hostname, connName string) {
@@ -640,7 +643,7 @@ func getAgentConfigMeta(tlsEnabled bool) []agentConfigMeta {
 		{
 			agentName:                "vm-adapter",
 			configDir:                "kubearmor-vm-adapter",
-			kmuxConfigPath:           filepath.Join(common.InContainerConfigDir, "kubearmor-vm-adapter", common.KmuxPoliciesFileName),
+			kmuxConfigPath:           filepath.Join(common.InContainerConfigDir, "kubearmor-vm-adapter", common.KmuxAnnotationFileName),
 			kmuxConfigTemplateString: kmuxConsumerConfig,
 			kmuxConfigFileName:       common.KmuxAnnotationFileName,
 		},
@@ -649,6 +652,13 @@ func getAgentConfigMeta(tlsEnabled bool) []agentConfigMeta {
 			configDir:            "kubearmor",
 			configFilePath:       "kubearmor_config.yaml",
 			configTemplateString: kubeArmorConfig,
+		},
+		{
+			agentName:                "vm-adapter",
+			configDir:                "kubearmor-vm-adapter",
+			kmuxConfigPath:           filepath.Join(common.InContainerConfigDir, "kubearmor-vm-adapter", common.KmuxPoliciesListFileName),
+			kmuxConfigTemplateString: kmuxPublisherConfig,
+			kmuxConfigFileName:       common.KmuxPoliciesListFileName,
 		},
 	}
 
@@ -717,6 +727,13 @@ func getAgentsKmuxConfigs() []agentConfigMeta {
 			kmuxConfigPath:           filepath.Join(common.InContainerConfigDir, "pea", common.KmuxStateEventFileName),
 			kmuxConfigTemplateString: kmuxConsumerConfig,
 			kmuxConfigFileName:       common.KmuxStateEventFileName,
+		},
+		{
+			agentName:                "pea",
+			configDir:                "pea",
+			kmuxConfigPath:           filepath.Join(common.InContainerConfigDir, "pea", common.KmuxPoliciesListFileName),
+			kmuxConfigTemplateString: kmuxConsumerConfig,
+			kmuxConfigFileName:       common.KmuxPoliciesListFileName,
 		},
 		{
 			agentName:                "sia",

--- a/pkg/onboard/node.go
+++ b/pkg/onboard/node.go
@@ -157,6 +157,7 @@ func (jc *JoinConfig) CreateBaseNodeConfig() error {
 		PolicyV1Topic:               getTopicName(jc.RMQTopicPrefix, "policy-v1"),
 		SummaryV2Topic:              getTopicName(jc.RMQTopicPrefix, "summary-v2"),
 		AnnotationTopic:             getTopicName(jc.RMQTopicPrefix, "annotation"),
+		PoliciesListTopic:           getTopicName(jc.RMQTopicPrefix, "policies-list"),
 
 		EnableHostPolicyDiscovery: jc.EnableHostPolicyDiscovery,
 
@@ -181,6 +182,8 @@ func (jc *JoinConfig) CreateBaseNodeConfig() error {
 	jc.TCArgs.SummaryKmuxConfig = common.KmuxSummaryFileName
 	jc.TCArgs.PolicyKmuxConfig = common.KmuxPolicyFileName
 	jc.TCArgs.AnnotationKmuxConfig = common.KmuxAnnotationFileName
+
+	jc.TCArgs.PoliciesListKmuxConfig = common.KmuxPoliciesListFileName
 
 	if jc.EnableVMScan {
 		jc.TCArgs.RRAConfigObject = jc.RRAConfigObject
@@ -311,13 +314,14 @@ func (jc *JoinConfig) JoinWorkerNode() error {
 	}
 
 	kmuxConfigFileTemplateMap := map[string]string{
-		"sumengine/" + common.KmuxConfigFileName:                kmuxPublisherConfig,
-		"sumengine/" + common.KmuxSummaryFileName:               kmuxPublisherConfig,
-		"kubearmor-vm-adapter/" + common.KmuxStateEventFileName: kmuxPublisherConfig,
-		"kubearmor-vm-adapter/" + common.KmuxAlertsFileName:     kmuxPublisherConfig,
-		"kubearmor-vm-adapter/" + common.KmuxLogsFileName:       kmuxPublisherConfig,
-		"kubearmor-vm-adapter/" + common.KmuxPoliciesFileName:   kmuxConsumerConfig,
-		"kubearmor-vm-adapter/" + common.KmuxAnnotationFileName: kmuxConsumerConfig,
+		"sumengine/" + common.KmuxConfigFileName:                  kmuxPublisherConfig,
+		"sumengine/" + common.KmuxSummaryFileName:                 kmuxPublisherConfig,
+		"kubearmor-vm-adapter/" + common.KmuxStateEventFileName:   kmuxPublisherConfig,
+		"kubearmor-vm-adapter/" + common.KmuxAlertsFileName:       kmuxPublisherConfig,
+		"kubearmor-vm-adapter/" + common.KmuxLogsFileName:         kmuxPublisherConfig,
+		"kubearmor-vm-adapter/" + common.KmuxPoliciesFileName:     kmuxConsumerConfig,
+		"kubearmor-vm-adapter/" + common.KmuxAnnotationFileName:   kmuxConsumerConfig,
+		"kubearmor-vm-adapter/" + common.KmuxPoliciesListFileName: kmuxPublisherConfig,
 	}
 	// Generate or copy kmux config files
 	for filePath, templateString := range kmuxConfigFileTemplateMap {

--- a/pkg/onboard/systemdUtils.go
+++ b/pkg/onboard/systemdUtils.go
@@ -242,6 +242,14 @@ func getSystemdAgentsKmuxConfigs(cc *ClusterConfig) []SystemdServiceObject {
 			AgentImage:               cc.KubeArmorVMAdapterImage,
 		},
 		{
+			AgentName:                cm.VMAdapter,
+			AgentDir:                 cm.VmAdapterConfigPath,
+			KmuxConfigPath:           filepath.Join(cm.VmAdapterConfigPath, cm.KmuxPoliciesListFileName),
+			KmuxConfigTemplateString: kmuxPublisherConfig,
+			KmuxConfigFileName:       cm.KmuxPoliciesListFileName,
+			AgentImage:               cc.KubeArmorVMAdapterImage,
+		},
+		{
 			AgentName:                cm.SummaryEngine,
 			AgentDir:                 cm.SumEngineConfigPath,
 			KmuxConfigPath:           filepath.Join(cm.SumEngineConfigPath, cm.KmuxSummaryFileName),
@@ -311,6 +319,14 @@ func getSystemdAgentsKmuxConfigs(cc *ClusterConfig) []SystemdServiceObject {
 			KmuxConfigPath:           filepath.Join(cm.PEAconfigPath, cm.KmuxStateEventFileName),
 			KmuxConfigTemplateString: kmuxConsumerConfig,
 			KmuxConfigFileName:       cm.KmuxStateEventFileName,
+			AgentImage:               cc.PEAImage,
+		},
+		{
+			AgentName:                cm.PEAAgent,
+			AgentDir:                 cm.PEAconfigPath,
+			KmuxConfigPath:           filepath.Join(cm.PEAconfigPath, cm.KmuxPoliciesListFileName),
+			KmuxConfigTemplateString: kmuxConsumerConfig,
+			KmuxConfigFileName:       cm.KmuxPoliciesListFileName,
 			AgentImage:               cc.PEAImage,
 		},
 		{

--- a/pkg/onboard/templates/docker-compose_cp-node.yaml
+++ b/pkg/onboard/templates/docker-compose_cp-node.yaml
@@ -274,6 +274,8 @@ services:
       {{- if trimPrefix "v" .ReleaseVersion | semverCompare ">0.12.0" }}
       - "--agents-version-file=/opt/agents-version"
       {{- end }}
+      - "--policy-list-enable={{.EnablePoliciesList}}"
+      - "--policy-list-relay-frequency={{.PoliciesListRefresh}}"
       {{- if or .TlsEnabled .RMQEnabled }}
       - "--tls"
       - "--policy-topic={{.PoliciesTopic}}"
@@ -284,6 +286,10 @@ services:
       - "--kmux-config-state=/opt/kubearmor-vm-adapter/{{.StateKmuxConfig}}"
       - "--kmux-config-alerts=/opt/kubearmor-vm-adapter/{{.AlertsKmuxConfig}}"
       - "--kmux-config-logs=/opt/kubearmor-vm-adapter/{{.LogsKmuxConfig}}"
+      {{- if .EnablePoliciesList }}
+      - "--kmux-policy-list=/opt/kubearmor-vm-adapter/{{.PoliciesListKmuxConfig}}"
+      - "--policy-list-topic={{.PoliciesListTopic}}"
+      {{- end }}
       {{- else }}
       - "--relay-server-addr={{.RelayServerURL}}"
       - "--sia-addr={{.SIAAddr}}"

--- a/pkg/onboard/templates/docker-compose_node.yaml
+++ b/pkg/onboard/templates/docker-compose_node.yaml
@@ -246,6 +246,8 @@ services:
       - "--spire-agent=unix:///var/run/spire/agent.sock"
       - "--spire-cert={{.SpireCert}}"
       {{- end }}
+      - "--policy-list-enable={{.EnablePoliciesList}}"
+      - "--policy-list-relay-frequency={{.PoliciesListRefresh}}"
       {{- if or .TlsEnabled  .RMQEnabled }}
       - "--tls"
       - "--policy-topic={{.PoliciesTopic}}"
@@ -256,6 +258,10 @@ services:
       - "--kmux-config-state=/opt/kubearmor-vm-adapter/{{.StateKmuxConfig}}"
       - "--kmux-config-alerts=/opt/kubearmor-vm-adapter/{{.AlertsKmuxConfig}}"
       - "--kmux-config-logs=/opt/kubearmor-vm-adapter/{{.LogsKmuxConfig}}"
+      {{- if .EnablePoliciesList }}
+      - "--kmux-policy-list=/opt/kubearmor-vm-adapter/{{.PoliciesListKmuxConfig}}"
+      - "--policy-list-topic={{.PoliciesListTopic}}"
+      {{- end }}
       {{- else }}
       - "--sia-addr={{.SIAAddr}}"
       - "--pea-addr={{.PEAAddr}}"

--- a/pkg/onboard/templates/pea-config.yaml
+++ b/pkg/onboard/templates/pea-config.yaml
@@ -34,6 +34,8 @@ annotation:
 non-k8s:
   enable: true
   policy-server-port: 32770
+  policy-list-kmux: {{.PoliciesListKmuxConfig}}
+  policy-list-topic: {{.PoliciesTopic}}
 tls:
   enabled: {{ or .TlsEnabled .RMQEnabled }}
   policy:
@@ -47,6 +49,19 @@ tls:
 
 policy-watcher:
   enable: false
+  delay: 00h00m10s
+  topic: discovery/custom-policy-v1
+  watchers: 
+    KubeArmorPolicy:
+      - selector.matchLabels
+      - selector.matchExpressions
+    KubeArmorHostPolicy:
+      - nodeSelector.matchLabels
+    NetworkPolicy:
+      - podSelector.matchLabels
+    KubeArmorClusterPolicy:
+      - selector.matchExpressions
+    AdmissionPolicy:
 
 deployMode: "vm"
 

--- a/pkg/onboard/templates/systemdTemplates/vm-adapter-config.yaml
+++ b/pkg/onboard/templates/systemdTemplates/vm-adapter-config.yaml
@@ -20,6 +20,10 @@ kmux-config-policy: /opt/kubearmor-vm-adapter/policies-kmux-config.yaml
 kmux-config-state: /opt/kubearmor-vm-adapter/state-kmux-config.yaml
 kmux-config-alerts: /opt/kubearmor-vm-adapter/alerts-kmux-config.yaml
 kmux-config-logs: /opt/kubearmor-vm-adapter/logs-kmux-config.yaml
+{{- if .EnablePoliciesList }}
+kmux-policy-list: "/opt/kubearmor-vm-adapter/{{.PoliciesListKmuxConfig}}"
+policy-list-topic: "{{.PoliciesListTopic}}"
+{{- end }}
 {{- else }}
 sia-addr: {{.SIAAddr}}
 
@@ -40,3 +44,6 @@ annotation-topic: {{.AnnotationTopic}}
 kmux-config-annotation: /opt/kubearmor-vm-adapter/annotation-kmux-config.yaml
 annotation-enable: true
 {{- end }}
+
+policy-list-enable: "{{.EnablePoliciesList}}"
+policy-list-relay-frequency: "{{.PoliciesListRefresh}}"

--- a/pkg/onboard/types.go
+++ b/pkg/onboard/types.go
@@ -329,6 +329,10 @@ type TemplateConfigArgs struct {
 	SummaryKmuxConfig    string `json:"summary_kmux_config,omitempty"`
 	AnnotationKmuxConfig string `json:"annotation_kmux_config,omitempty"`
 
+	PoliciesListKmuxConfig string        `json:"policies_list_kmux_config,omitempty"`
+	EnablePoliciesList     bool          `json:"enable_policies_list,omitempty"`
+	PoliciesListRefresh    time.Duration `json:"policies_list_refresh,omitempty"`
+
 	// container security
 	SecureContainers bool `json:"secure_containers,omitempty"`
 	// host policy discovery
@@ -352,13 +356,14 @@ type TemplateConfigArgs struct {
 	TlsCertFile string `json:"tls_cert_file,omitempty"`
 
 	// topic config
-	PoliciesTopic   string `json:"policies_topic,omitempty"`
-	StateEventTopic string `json:"state_event_topic,omitempty"`
-	LogsTopic       string `json:"logs_topic,omitempty"`
-	AlertsTopic     string `json:"alerts_topic,omitempty"`
-	PolicyV1Topic   string `json:"policyv1_topic,omitempty"`
-	SummaryV2Topic  string `json:"summaryv2_topic,omitempty"`
-	AnnotationTopic string `json:"annotation_topic,omitempty"`
+	PoliciesTopic     string `json:"policies_topic,omitempty"`
+	StateEventTopic   string `json:"state_event_topic,omitempty"`
+	LogsTopic         string `json:"logs_topic,omitempty"`
+	AlertsTopic       string `json:"alerts_topic,omitempty"`
+	PolicyV1Topic     string `json:"policyv1_topic,omitempty"`
+	SummaryV2Topic    string `json:"summaryv2_topic,omitempty"`
+	AnnotationTopic   string `json:"annotation_topic,omitempty"`
+	PoliciesListTopic string `json:"policies_list_topic,omitempty"`
 
 	// rra configs
 	RRAConfigObject RRAConfig `json:"-"`


### PR DESCRIPTION
JIRA: https://accu-knox.atlassian.net/browse/CNAPP-24247

This PR contains the following changes:
- new flags `--enable-policies-list` and `--policies-list-refresh-time 5m` to control policy list sync
- updated configs for pea and vm-adapter