### PR TITLE
fix(image): do not add _os-arch to systemd image

### DIFF
--- a/pkg/onboard/image.go
+++ b/pkg/onboard/image.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	cm "github.com/accuknox/accuknox-cli-v2/pkg/common"
 )
 
 type imageOptions struct {
@@ -36,6 +38,10 @@ func getImage(customRegistry, defaultRegistry, defaultRepo, customImage, default
 		if preserveUpstream {
 			repo = defaultRepo
 		}
+	}
+
+	if (customImage == "" && customTag == "") && tagSuffix == "" {
+		tagSuffix = cm.SystemdTagSuffix
 	}
 
 	// get image and tag

--- a/pkg/onboard/onboard.go
+++ b/pkg/onboard/onboard.go
@@ -374,10 +374,6 @@ func (cc *ClusterConfig) PopulateAccessKeyConfig(url, key, clusterName, vmName, 
 
 func (cc *ClusterConfig) PopulateImageDetails(releaseInfo cm.ReleaseMetadata, images *ImageVersions, registry, registryConfigPath, tagSuffix string, preserveUpstream, insecureRegistryConnection, httpRegistryConnection bool) error {
 
-	if tagSuffix == "" {
-		tagSuffix = cm.SystemdTagSuffix
-	}
-
 	var err error
 	// mode specific config
 	switch cc.Mode {


### PR DESCRIPTION
With the current implementation when we pass custom image or tag to any of the agents in systemd mode we append `_OS-ARCH` to the image before pulling it from the registry. This is not required if a custom image or tag is provided by the user.

This PR contains the following changes:
- only append `_OS-ARCH` to systemd image if custom image or tag is not provided 