### PR TITLE
chore(upgrade): cherry-pick version to v0.9

### DIFF
--- a/cmd/onboard-vm-node.go
+++ b/cmd/onboard-vm-node.go
@@ -235,8 +235,6 @@ func init() {
 
 	joinNodeCmd.PersistentFlags().StringVarP(&releaseVersion, "version", "v", "", "version to use - recommended to keep same as control plane node version")
 
-	joinNodeCmd.PersistentFlags().StringVar(&tls.CaCert, "ca-cert", "", "ca certificate in bas64 encoded format to validate tls connection")
-
 	joinNodeCmd.PersistentFlags().BoolVar(&deploySumEngine, "deploy-summary-engine", false, "to deploy summary engine in worker node")
 
 	// spire config - to use spire and spire cert for tls

--- a/cmd/onboard-vm.go
+++ b/cmd/onboard-vm.go
@@ -150,6 +150,8 @@ func init() {
 	onboardVMCmd.PersistentFlags().BoolVar(&tls.Generate, "tls-gen", false, "generate TLS certificates for rabbitmq connection (generates CA, Cert, and Key)")
 	onboardVMCmd.PersistentFlags().StringVar(&tls.CaPath, "ca-path", "", "path to ca certificate file")
 
+	onboardVMCmd.PersistentFlags().StringVar(&tls.CaCert, "ca-cert", "", "ca certificate in bas64 encoded format to validate tls connection")
+
 	onboardVMCmd.PersistentFlags().StringVar(&topicPrefix, "cp-name", "", "control plane node name to be used as topic prefix")
 
 	onboardVMCmd.PersistentFlags().StringArrayVar(&tls.Organization, "tls-org", []string{"accuknox"}, "Organization for TLS certificates")

--- a/pkg/onboard/cpNodeSD.go
+++ b/pkg/onboard/cpNodeSD.go
@@ -19,7 +19,6 @@ func (ic *InitConfig) InitializeControlPlaneSD() error {
 
 	ic.TCArgs.SpireSecretDir = ic.SpireSecretDir
 	ic.TCArgs.KubeArmorURL = "0.0.0.0:32767"
-	ic.TCArgs.KubeArmorPort = "32767"
 
 	ic.TCArgs.KubeArmorAddr = "0.0.0.0"
 	ic.TCArgs.KubeArmorPort = "32767"

--- a/pkg/onboard/image.go
+++ b/pkg/onboard/image.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	cm "github.com/accuknox/accuknox-cli-v2/pkg/common"
 )
 
 type imageOptions struct {
@@ -36,6 +38,10 @@ func getImage(customRegistry, defaultRegistry, defaultRepo, customImage, default
 		if preserveUpstream {
 			repo = defaultRepo
 		}
+	}
+
+	if (customImage == "" && customTag == "") && tagSuffix == "" {
+		tagSuffix = cm.SystemdTagSuffix
 	}
 
 	// get image and tag

--- a/pkg/onboard/onboard.go
+++ b/pkg/onboard/onboard.go
@@ -374,10 +374,6 @@ func (cc *ClusterConfig) PopulateAccessKeyConfig(url, key, clusterName, vmName, 
 
 func (cc *ClusterConfig) PopulateImageDetails(releaseInfo cm.ReleaseMetadata, images *ImageVersions, registry, registryConfigPath, tagSuffix string, preserveUpstream, insecureRegistryConnection, httpRegistryConnection bool) error {
 
-	if tagSuffix == "" {
-		tagSuffix = cm.SystemdTagSuffix
-	}
-
 	var err error
 	// mode specific config
 	switch cc.Mode {

--- a/pkg/onboard/systemdUtils.go
+++ b/pkg/onboard/systemdUtils.go
@@ -695,6 +695,10 @@ func (cc *ClusterConfig) SystemdInstall() error {
 			continue
 		}
 
+		if (cc.Tls.RMQEnabled || cc.Tls.Enabled) && obj.AgentName == cm.RelayServer {
+			continue
+		}
+
 		if !cc.SkipDownload {
 			// stop existing service first otherwise errors are encountered due to
 			// busy binary

--- a/pkg/onboard/templates/docker-compose_cp-node.yaml
+++ b/pkg/onboard/templates/docker-compose_cp-node.yaml
@@ -204,7 +204,7 @@ services:
           exec /KubeArmor/kubearmor "$$@"
       - --
   {{- end }}
-
+{{- if not (or .RMQEnabled .TlsEnabled) }}
   kubearmor-relay-server:
     profiles:
       - "accuknox-agents"
@@ -240,7 +240,7 @@ services:
         limits:
           cpus: '{{.AgentsCPUs}}'
           memory: {{.AgentsMemoryMax}}
-
+{{- end }}
   kubearmor-vm-adapter:
     profiles:
       - "kubearmor-only"
@@ -274,8 +274,10 @@ services:
       {{- if trimPrefix "v" .ReleaseVersion | semverCompare ">0.12.0" }}
       - "--agents-version-file=/opt/agents-version"
       {{- end }}
+      {{- if trimPrefix "v" .ReleaseVersion | semverCompare ">0.12.2" }}
       - "--policy-list-enable={{.EnablePoliciesList}}"
       - "--policy-list-relay-frequency={{.PoliciesListRefresh}}"
+      {{- end }}
       {{- if or .TlsEnabled .RMQEnabled }}
       - "--tls"
       - "--policy-topic={{.PoliciesTopic}}"
@@ -286,7 +288,7 @@ services:
       - "--kmux-config-state=/opt/kubearmor-vm-adapter/{{.StateKmuxConfig}}"
       - "--kmux-config-alerts=/opt/kubearmor-vm-adapter/{{.AlertsKmuxConfig}}"
       - "--kmux-config-logs=/opt/kubearmor-vm-adapter/{{.LogsKmuxConfig}}"
-      {{- if .EnablePoliciesList }}
+      {{- if and .EnablePoliciesList (trimPrefix "v" .ReleaseVersion | semverCompare ">0.12.2") }}
       - "--kmux-policy-list=/opt/kubearmor-vm-adapter/{{.PoliciesListKmuxConfig}}"
       - "--policy-list-topic={{.PoliciesListTopic}}"
       {{- end }}
@@ -394,8 +396,10 @@ services:
         condition: service_completed_successfully
         {{- end }}
       {{- end }}
+      {{- if not (or .TlsEnabled  .RMQEnabled) }}
       kubearmor-relay-server:
         condition: service_started
+      {{- end }}
       summary-engine:
         condition: service_started
       {{- if .DeployDiscover }}
@@ -493,8 +497,10 @@ services:
         condition: service_completed_successfully
         {{- end }}
       {{- end }}
+      {{- if not (or .TlsEnabled .RMQEnabled ) }}
       kubearmor-relay-server:
         condition: service_started
+      {{- end }}
     container_name: policy-enforcement-agent
     image: "{{.PEAImage}}"
     user: "0:0"
@@ -584,7 +590,11 @@ services:
       rabbitmq:
         condition: service_started
       {{- end }}
+      {{- if not (or .TlsEnabled .RMQEnabled ) }}
       kubearmor-relay-server:
+        condition: service_started
+      {{- end }}
+      kubearmor:
         condition: service_started
     container_name: summary-engine
     image: "{{.SumEngineImage}}"
@@ -622,7 +632,11 @@ services:
       rabbitmq:
         condition: service_started
       {{- end }}
+      {{- if not (or .TlsEnabled .RMQEnabled ) }}
       kubearmor-relay-server:
+        condition: service_started
+      {{- end }}
+      kubearmor:
         condition: service_started
     container_name: hardening-agent
     image: "{{.HardeningAgentImage}}"

--- a/pkg/onboard/templates/docker-compose_node.yaml
+++ b/pkg/onboard/templates/docker-compose_node.yaml
@@ -246,8 +246,10 @@ services:
       - "--spire-agent=unix:///var/run/spire/agent.sock"
       - "--spire-cert={{.SpireCert}}"
       {{- end }}
+      {{- if trimPrefix "v" .ReleaseVersion | semverCompare ">0.12.2" }}
       - "--policy-list-enable={{.EnablePoliciesList}}"
       - "--policy-list-relay-frequency={{.PoliciesListRefresh}}"
+      {{- end }}
       {{- if or .TlsEnabled  .RMQEnabled }}
       - "--tls"
       - "--policy-topic={{.PoliciesTopic}}"
@@ -258,7 +260,7 @@ services:
       - "--kmux-config-state=/opt/kubearmor-vm-adapter/{{.StateKmuxConfig}}"
       - "--kmux-config-alerts=/opt/kubearmor-vm-adapter/{{.AlertsKmuxConfig}}"
       - "--kmux-config-logs=/opt/kubearmor-vm-adapter/{{.LogsKmuxConfig}}"
-      {{- if .EnablePoliciesList }}
+      {{- if and .EnablePoliciesList (trimPrefix "v" .ReleaseVersion | semverCompare ">0.12.2") }}
       - "--kmux-policy-list=/opt/kubearmor-vm-adapter/{{.PoliciesListKmuxConfig}}"
       - "--policy-list-topic={{.PoliciesListTopic}}"
       {{- end }}

--- a/pkg/onboard/templates/systemdTemplates/feeder-service-env
+++ b/pkg/onboard/templates/systemdTemplates/feeder-service-env
@@ -3,8 +3,13 @@ CLUSTER_NAME="default"
 HUBBLE_ENABLED=false
 KAFKA_ENABLED=false
 KUBEARMOR_ENABLED=true
+{{ if or .TlsEnabled .RMQEnabled }}
+KUBEARMOR_URL="{{.KubeArmorAddr}}"
+KUBEARMOR_PORT="{{.KubeArmorPort}}"
+{{ else }}
 KUBEARMOR_URL="{{.RelayServerAddr}}"
 KUBEARMOR_PORT="{{.RelayServerPort}}"
+{{ end }}
 KMUX_LOGS_ENABLED={{.EnableLogs}}
 KMUX_CONFIG_PATH={{.KmuxConfigPath}}
 IGNORE_SUMMARY_EVENTS="Network:AF_UNIX,AF_NETLINK"

--- a/pkg/onboard/templates/systemdTemplates/vm-adapter-config.yaml
+++ b/pkg/onboard/templates/systemdTemplates/vm-adapter-config.yaml
@@ -20,7 +20,7 @@ kmux-config-policy: /opt/kubearmor-vm-adapter/policies-kmux-config.yaml
 kmux-config-state: /opt/kubearmor-vm-adapter/state-kmux-config.yaml
 kmux-config-alerts: /opt/kubearmor-vm-adapter/alerts-kmux-config.yaml
 kmux-config-logs: /opt/kubearmor-vm-adapter/logs-kmux-config.yaml
-{{- if .EnablePoliciesList }}
+{{- if and .EnablePoliciesList (trimPrefix "v" .ReleaseVersion | semverCompare ">0.12.2") }}
 kmux-policy-list: "/opt/kubearmor-vm-adapter/{{.PoliciesListKmuxConfig}}"
 policy-list-topic: "{{.PoliciesListTopic}}"
 {{- end }}
@@ -45,5 +45,7 @@ kmux-config-annotation: /opt/kubearmor-vm-adapter/annotation-kmux-config.yaml
 annotation-enable: true
 {{- end }}
 
+{{- if trimPrefix "v" .ReleaseVersion | semverCompare ">0.12.2" }}
 policy-list-enable: "{{.EnablePoliciesList}}"
 policy-list-relay-frequency: "{{.PoliciesListRefresh}}"
+{{- end }}


### PR DESCRIPTION
This PR contains the following changes:
- do not deploy if rmq based installation is enabled
- do not use `_OS-ARCH` suffix to systemd image if custom images are provided 
- only add new vm-adapter flags if version > 0.12.2