### PR TITLE
fix(extraction): only extract specified paths

### DIFF
--- a/pkg/onboard/systemdUtils.go
+++ b/pkg/onboard/systemdUtils.go
@@ -31,6 +31,13 @@ var (
 	cpNodeAgents     = []string{cm.SpireAgent, cm.SIAAgent, cm.PEAAgent, cm.FeederService, cm.SummaryEngine, cm.DiscoverAgent, cm.HardeningAgent}
 )
 
+// while extracting only files with these
+// prefixes will be extracted
+var allowedPrefixes = []string{
+	"opt/",
+	"usr/lib/systemd/system/",
+}
+
 func (cc *ClusterConfig) CreateSystemdServiceObjects() {
 	systemdObjects := []SystemdServiceObject{
 		{
@@ -592,9 +599,18 @@ func ExtractAgent(fileName string) error {
 
 	tarReader := tar.NewReader(gzipReader)
 
+	isAllowed := func(name string) bool {
+		normalized := strings.TrimPrefix(name, "/")
+		for _, prefix := range allowedPrefixes {
+			if strings.HasPrefix(normalized, prefix) {
+				return true
+			}
+		}
+		return false
+	}
+
 	for {
 		header, err := tarReader.Next()
-
 		if err == io.EOF {
 			break
 		}
@@ -606,6 +622,11 @@ func ExtractAgent(fileName string) error {
 		if header.Typeflag == tar.TypeDir {
 			continue
 		}
+
+		if !isAllowed(header.Name) {
+			continue
+		}
+
 		rootDir := "/"
 
 		// Extract the file

--- a/pkg/onboard/systemd_service_linux.go
+++ b/pkg/onboard/systemd_service_linux.go
@@ -83,7 +83,8 @@ func StopSystemdService(serviceName string, skipDeleteDisable, force bool) error
 
 	if !skipDeleteDisable {
 		if _, err := conn.DisableUnitFilesContext(ctx, []string{serviceName}, false); err != nil {
-			if !strings.Contains(err.Error(), "does not exist") {
+			if !strings.Contains(err.Error(), "does not exist") &&
+				!strings.Contains(err.Error(), "No such file or directory") {
 				logger.Error("Failed to disable %s : %v", serviceName, err)
 				return err
 			}


### PR DESCRIPTION
While extracting systemd tar files we were extracting all data from the tar which may cause replacement of the entire `/` folder. We need to introduce a check to extract only specific folders where the binary and service file resides. 
 
This PR contains the following changes:
- only extract if folder struct matches 
   - `opt/`
   - `usr/lib/systemd/system/`