### PR TITLE
fix(vm-adapter): update vm-adapter config

### DIFF
--- a/pkg/common/release.json
+++ b/pkg/common/release.json
@@ -2164,7 +2164,7 @@
       "creation_time": "1781603518",
       "kubearmor_tag": "v1.6.18",
       "kubearmor_relay_tag": "v0.0.4",
-      "kubearmor_vm_adapter_tag": "v0.1.26",
+      "kubearmor_vm_adapter_tag": "v0.1.27",
       "spire_agent_tag": "v2.0.14",
       "sia_tag": "v0.8.14",
       "sia_image": "public.ecr.aws/k9v9d5v2/shared-informer-agent",

--- a/pkg/onboard/cpNode.go
+++ b/pkg/onboard/cpNode.go
@@ -370,7 +370,7 @@ func (ic *InitConfig) populateCommonArgs() {
 	ic.TCArgs.PolicyV1Topic = getTopicName(ic.RMQTopicPrefix, "policy-v1")
 	ic.TCArgs.SummaryV2Topic = getTopicName(ic.RMQTopicPrefix, "summary-v2")
 	ic.TCArgs.AnnotationTopic = getTopicName(ic.RMQTopicPrefix, "annotation")
-	ic.TCArgs.PoliciesListKmuxConfig = getTopicName(ic.RMQTopicPrefix, "policies-list")
+	ic.TCArgs.PoliciesListTopic = getTopicName(ic.RMQTopicPrefix, "policies-list")
 
 	ic.TCArgs.SplunkConfigObject = ic.Splunk
 }

--- a/pkg/onboard/templates/systemdTemplates/vm-adapter-config.yaml
+++ b/pkg/onboard/templates/systemdTemplates/vm-adapter-config.yaml
@@ -46,6 +46,6 @@ annotation-enable: true
 {{- end }}
 
 {{- if trimPrefix "v" .ReleaseVersion | semverCompare ">0.12.2" }}
-policy-list-enable: "{{.EnablePoliciesList}}"
+policy-list-enable: {{.EnablePoliciesList}}
 policy-list-relay-frequency: "{{.PoliciesListRefresh}}"
 {{- end }}


### PR DESCRIPTION
JIRA: https://accu-knox.atlassian.net/browse/CNAPP-15731

In RabbitMQ mode deployment vm-adapter was failing with error sink not supported the issue stemmed from kmux file variable mismatch.

This PR contains the following changes:
- update config file variable while creating policy list sink