### PR TITLE
fix(compose): use consistent environment variable syntax

### DIFF
--- a/pkg/onboard/templates/docker-compose_cp-node.yaml
+++ b/pkg/onboard/templates/docker-compose_cp-node.yaml
@@ -352,7 +352,7 @@ services:
     labels:
       app: shared-informer-agent
     environment:
-    - "test=true"
+    - "AGENT=true"
     {{- if .ProxyEnabled }}
     - "JOIN_TOKEN={{.JoinToken}}"
     {{- end }}
@@ -513,7 +513,7 @@ services:
       # for spire socket
       - "/var/run:/var/run:ro"
     environment:
-    - "test=true"
+    - "AGENT=true"
     {{- if .ProxyEnabled  }}
     - "JOIN_TOKEN={{.JoinToken}}"
     {{- end }}
@@ -555,7 +555,7 @@ services:
     container_name: discover
     image: "{{.DiscoverImage}}"
     environment:
-      "ENABLE_GRPC": 'false'
+      ENABLE_GRPC: "false"
     pull_policy: "{{.ImagePullPolicy}}"
     command: ["--config", "/opt/discover/config.yaml", "--kmux-config", "/opt/discover/kmux-config.yaml"]
     labels:

--- a/pkg/onboard/templates/docker-compose_node.yaml
+++ b/pkg/onboard/templates/docker-compose_node.yaml
@@ -224,14 +224,14 @@ services:
     user: "0:0"
     pull_policy: "{{.ImagePullPolicy}}"
     environment:
-    - "test=true"
+    - "AGENT=true"
     {{- if .ProxyEnabled  }}
     - "JOIN_TOKEN={{.JoinToken}}"
     {{- end }}
     {{- range .ProxyExtraArgs }}
     - {{ . }}
     {{- end }}
-    - KUBEARMOR_CFG: "/opt/kubearmor/config/kubearmor_config.yaml"
+    - "KUBEARMOR_CFG=/opt/kubearmor/config/kubearmor_config.yaml"
     command:
       - "--kubearmor-addr={{.KubeArmorURL}}"
       - "--relay-server-addr={{.RelayServerURL}}"
@@ -319,7 +319,7 @@ services:
     labels:
       app: sumengine
     environment:
-    - "test=true"
+    - "AGENT=true"
     {{- if .ProxyEnabled  }}
     - "JOIN_TOKEN={{.JoinToken}}"
     {{- end }}


### PR DESCRIPTION

### JIRA: [CNAPP-30380](https://accu-knox.atlassian.net/browse/CNAPP-30380)

This PR contains the following changes:
- Fixes the Docker Compose environment variable configuration.
- Uses a consistent syntax for all environment variables.

#### Root Cause
The `environment` section mixed list and mapping syntax, causing Docker Compose to fail with:

.environment.[1]: unexpected type map[string]interface {}

#### Testing
- Verified `knoxctl onboard vm node` starts successfully.

[CNAPP-30380]: https://accu-knox.atlassian.net/browse/CNAPP-30380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ