### PR TITLE
fix(registry): pull agents from custom registry if present

### DIFF
--- a/cmd/onboard.go
+++ b/cmd/onboard.go
@@ -42,7 +42,7 @@ func init() {
 		os.Exit(1)
 	}
 
-	onboardCmd.PersistentFlags().StringVarP(&registry, "registry", "r", "docker.io", "the registry to authenticate with (default - DockerHub)")
+	onboardCmd.PersistentFlags().StringVarP(&registry, "registry", "r", "", "the registry to authenticate with (default - DockerHub)")
 	onboardCmd.PersistentFlags().StringVarP(&registryConfigPath, "registry-config-path", "", "", "path to pre-existing OCI registry config")
 
 	onboardCmd.PersistentFlags().BoolVar(&dryRun, "dry-run", false, "only generate manifests and don't onboard anything")

--- a/cmd/vm-download.go
+++ b/cmd/vm-download.go
@@ -77,7 +77,7 @@ func init() {
 	vmDownload.PersistentFlags().StringVar(&archs, "arch", "amd64,arm64", "comma separated list of architectures to download, Default: amd64,arm64")
 	vmDownload.PersistentFlags().StringVar(&downloadOpts.SavePath, "save-path", "", "path to save downloaded binaries/images, Default: current directory")
 
-	vmDownload.PersistentFlags().StringVarP(&registry, "registry", "r", "docker.io", "the registry to authenticate with (default - DockerHub)")
+	vmDownload.PersistentFlags().StringVarP(&registry, "registry", "r", "", "the registry to authenticate with (default - DockerHub)")
 	vmDownload.PersistentFlags().StringVarP(&registryConfigPath, "registry-config-path", "", "", "path to pre-existing OCI registry config")
 
 	vmDownload.PersistentFlags().BoolVarP(&plainHTTP, "plain-http", "", false, "use plain HTTP everywhere")

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -58,6 +58,7 @@ const (
 	DefaultConfigPathDirName = ".accuknox-config"
 
 	DefaultDockerRegistry = "docker.io"
+	DefaultECRRegistry    = "public.ecr.aws"
 
 	// KubeArmor related image/image registries are fixed as of now
 	DefaultKubeArmorRepo      = "kubearmor"

--- a/pkg/onboard/image.go
+++ b/pkg/onboard/image.go
@@ -2,6 +2,7 @@ package onboard
 
 import (
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -23,6 +24,7 @@ type imageOptions struct {
 
 // getImage takes image options and returns the final image
 func getImage(mode VMMode, customRegistry, defaultRegistry, defaultRepo, customImage, defaultImage, customTag, defaultTag, tagPrefixToTrim, tagSuffix string, preserveUpstream bool) (string, error) {
+
 	var registry, repo, imageName, tag string
 
 	if customRegistry != "" {
@@ -116,6 +118,18 @@ func getImage(mode VMMode, customRegistry, defaultRegistry, defaultRepo, customI
 		repoAndRegistry = registry
 	} else if repo != "" {
 		repoAndRegistry = repo
+	}
+
+	if customRegistry != "" {
+		repoRegistrySlice := splitLast(repoAndRegistry, "/")
+		var repoName string
+		if len(repoRegistrySlice) > 1 {
+			repoName = repoRegistrySlice[1]
+		}
+		repoAndRegistry = customRegistry
+		if preserveUpstream {
+			repoAndRegistry = filepath.Join(repoAndRegistry, repoName)
+		}
 	}
 
 	return fmt.Sprintf("%s/%s:%s", repoAndRegistry, imageName, tag), nil

--- a/pkg/onboard/onboard.go
+++ b/pkg/onboard/onboard.go
@@ -427,7 +427,7 @@ func (cc *ClusterConfig) PopulateImageDetails(releaseInfo cm.ReleaseMetadata, im
 
 		cc.SPIREAgentImage, err = getImage(VMMode_Docker, registry, cm.DefaultDockerRegistry,
 			cm.DefaultAccuKnoxRepo, images.SpireImage, cm.DefaultSPIREAgentImage,
-			"", releaseInfo.SPIREAgentImageTag, "", "", preserveUpstream)
+			"latest", releaseInfo.SPIREAgentImageTag, "", "", preserveUpstream)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR contains the following changes:
- pull agents from custom registry if provided
- remove hard coded `docker.io` registry value
- revert changes to spire agent docker image tag    