### PR TITLE
fix(events): upgrade vm-adapter version for kubearmor

### DIFF
--- a/pkg/common/release.json
+++ b/pkg/common/release.json
@@ -2185,7 +2185,7 @@
       "creation_time": "1781603518",
       "kubearmor_tag": "v1.7.4",
       "kubearmor_relay_tag": "v0.0.4",
-      "kubearmor_vm_adapter_tag": "v0.1.28",
+      "kubearmor_vm_adapter_tag": "v0.1.29",
       "spire_agent_tag": "v2.0.14",
       "sia_tag": "v0.8.14",
       "sia_image": "public.ecr.aws/k9v9d5v2/shared-informer-agent",


### PR DESCRIPTION
JIRA: https://accu-knox.atlassian.net/browse/CNAPP-30407

This PR contains the following changes:
- upgrade vm-adapter to configure health check port for kubearmor